### PR TITLE
Update compiler to 0.8.4

### DIFF
--- a/contracts/MolochSummoner.sol
+++ b/contracts/MolochSummoner.sol
@@ -1,6 +1,6 @@
 // Based on https://github.com/HausDAO/Molochv2.1
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.4;
 
 /**
  * @dev Contract module that helps prevent reentrant calls to a function.

--- a/contracts/MolochSummoner.sol
+++ b/contracts/MolochSummoner.sol
@@ -1,6 +1,6 @@
 // Based on https://github.com/HausDAO/Molochv2.1
-
-pragma solidity 0.6.1;
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.0;
 
 /**
  * @dev Contract module that helps prevent reentrant calls to a function.
@@ -18,7 +18,7 @@ pragma solidity 0.6.1;
  * to protect against it, check out our blog post
  * https://blog.openzeppelin.com/reentrancy-after-istanbul/[Reentrancy After Istanbul].
  */
-contract ReentrancyGuard {
+abstract contract ReentrancyGuard {
     // Booleans are more expensive than uint256 or any type that takes up a full
     // word because each write operation emits an extra SLOAD to first read the
     // slot's contents, replace the bits taken up by the boolean, and then write
@@ -35,7 +35,7 @@ contract ReentrancyGuard {
 
     uint256 private _status;
 
-    constructor () internal {
+    constructor () {
         _status = _NOT_ENTERED;
     }
 
@@ -79,43 +79,8 @@ interface IERC20 {
     event Approval(address indexed owner, address indexed spender, uint256 value);
 }
 
-library SafeMath {
-    function mul(uint256 a, uint256 b) internal pure returns (uint256) {
-        if (a == 0) {
-            return 0;
-        }
-
-        uint256 c = a * b;
-        require(c / a == b);
-
-        return c;
-    }
-
-    function div(uint256 a, uint256 b) internal pure returns (uint256) {
-
-        require(b > 0);
-        uint256 c = a / b;
-
-        return c;
-    }
-
-    function sub(uint256 a, uint256 b) internal pure returns (uint256) {
-        require(b <= a);
-        uint256 c = a - b;
-
-        return c;
-    }
-
-    function add(uint256 a, uint256 b) internal pure returns (uint256) {
-        uint256 c = a + b;
-        require(c >= a);
-
-        return c;
-    }
-}
 
 contract Moloch is ReentrancyGuard {
-    using SafeMath for uint256;
 
     /***************
     GLOBAL CONSTANTS
@@ -220,8 +185,9 @@ contract Moloch is ReentrancyGuard {
         bool[6] flags; // [sponsored, processed, didPass, cancelled, whitelist, guildkick]
         string details; // proposal details - could be IPFS hash, plaintext, or JSON
         uint256 maxTotalSharesAndLootAtYesVote; // the maximum # of total shares encountered at a yes vote on this proposal
-        mapping(address => Vote) votesByMember; // the votes on this proposal by each member
     }
+
+    mapping(uint256 => mapping(address => Vote)) voteHistory; // maps voting decisions on proposals proposal => member => voted
 
     mapping(address => bool) public tokenWhitelist;
     address[] public approvedTokens;
@@ -320,10 +286,8 @@ contract Moloch is ReentrancyGuard {
     ) internal {
         if (mint) {
             if (members[applicant].exists) {
-                members[applicant].shares = members[applicant].shares.add(
-                    shares
-                );
-                members[applicant].loot = members[applicant].loot.add(loot);
+                members[applicant].shares = members[applicant].shares + shares;
+                members[applicant].loot = members[applicant].loot + loot;
 
                 // the applicant is a new member, create a new record for them
             } else {
@@ -349,16 +313,16 @@ contract Moloch is ReentrancyGuard {
                 );
                 memberAddressByDelegateKey[applicant] = applicant;
             }
-            totalShares = totalShares.add(shares);
-            totalLoot = totalLoot.add(loot);
+            totalShares = totalShares + shares;
+            totalLoot = totalLoot + loot;
         } else {
-            members[applicant].shares = members[applicant].shares.sub(shares);
-            members[applicant].loot = members[applicant].loot.sub(loot);
-            totalShares = totalShares.sub(shares);
-            totalLoot = totalLoot.sub(loot);
+            members[applicant].shares = members[applicant].shares - shares;
+            members[applicant].loot = members[applicant].loot - loot;
+            totalShares = totalShares - shares;
+            totalLoot = totalLoot - loot;
         }
         require(
-            totalShares.add(shares).add(loot) <= MAX_NUMBER_OF_SHARES_AND_LOOT,
+            (totalShares + shares + loot) <= MAX_NUMBER_OF_SHARES_AND_LOOT,
             "too many shares requested"
         );
     }
@@ -394,7 +358,7 @@ contract Moloch is ReentrancyGuard {
         require(_summoner != address(0), "summoner cannot be 0");
         members[_summoner] = Member(_summoner, 1, 0, true, 0, 0);
         memberAddressByDelegateKey[_summoner] = _summoner;
-        totalShares = totalShares.add(1);
+        totalShares++;
 
         
         require(totalShares <= MAX_NUMBER_OF_SHARES_AND_LOOT, "too many shares requested");
@@ -412,7 +376,7 @@ contract Moloch is ReentrancyGuard {
         proposalDeposit = _proposalDeposit;
         dilutionBound = _dilutionBound;
         processingReward = _processingReward;
-        summoningTime = now;
+        summoningTime = block.timestamp;
         initialized = true;
     }
 
@@ -429,7 +393,7 @@ contract Moloch is ReentrancyGuard {
         address paymentToken,
         string memory details
     ) public nonReentrant returns (uint256 proposalId) {
-        require(sharesRequested.add(lootRequested) <= MAX_NUMBER_OF_SHARES_AND_LOOT, "too many shares requested");
+        require((sharesRequested+ lootRequested) <= MAX_NUMBER_OF_SHARES_AND_LOOT, "too many shares requested");
         require(tokenWhitelist[tributeToken], "tributeToken is not whitelisted");
         require(tokenWhitelist[paymentToken], "payment is not whitelisted");
         require(applicant != address(0), "applicant cannot be 0");
@@ -488,7 +452,7 @@ contract Moloch is ReentrancyGuard {
     ) internal {
         require(msg.value >= spamPrevention, "spam prevention on");
         if (spamPrevention > 0) {
-            (bool success, ) = spamPreventionAddr.call.value(msg.value)("");
+            (bool success, ) = spamPreventionAddr.call{value: msg.value}("");
             require(success, "failed");
         }
         Proposal memory proposal = Proposal({
@@ -548,8 +512,8 @@ contract Moloch is ReentrancyGuard {
         // compute startingPeriod for proposal
         uint256 startingPeriod = max(
             getCurrentPeriod(),
-            proposalQueue.length == 0 ? 0 : proposals[proposalQueue[proposalQueue.length.sub(1)]].startingPeriod
-        ).add(1);
+            proposalQueue.length == 0 ? 0 : proposals[proposalQueue[proposalQueue.length - 1]].startingPeriod
+        ) + 1;
 
         proposal.startingPeriod = startingPeriod;
 
@@ -561,7 +525,7 @@ contract Moloch is ReentrancyGuard {
         // append proposal to the queue
         proposalQueue.push(proposalId);
         
-        emit SponsorProposal(msg.sender, memberAddress, proposalId, proposalQueue.length.sub(1), startingPeriod);
+        emit SponsorProposal(msg.sender, memberAddress, proposalId, proposalQueue.length - 1, startingPeriod);
     }
 
     // NOTE: In MolochV2 proposalIndex !== proposalId
@@ -577,13 +541,13 @@ contract Moloch is ReentrancyGuard {
 
         require(getCurrentPeriod() >= proposal.startingPeriod, "voting period has not started");
         require(!hasVotingPeriodExpired(proposal.startingPeriod), "proposal voting period has expired");
-        require(proposal.votesByMember[memberAddress] == Vote.Null, "member has already voted");
+        require(voteHistory[proposalIndex][memberAddress] == Vote.Null, "member has already voted");
         require(vote == Vote.Yes || vote == Vote.No, "vote must be either Yes or No");
 
-        proposal.votesByMember[memberAddress] = vote;
+        voteHistory[proposalIndex][memberAddress] = vote;
 
         if (vote == Vote.Yes) {
-            proposal.yesVotes = proposal.yesVotes.add(member.shares);
+            proposal.yesVotes = proposal.yesVotes + member.shares;
 
             // set highest index (latest) yes vote - must be processed for member to ragequit
             if (proposalIndex > member.highestIndexYesVote) {
@@ -591,12 +555,12 @@ contract Moloch is ReentrancyGuard {
             }
 
             // set maximum of total shares encountered at a yes vote - used to bound dilution for yes voters
-            if (totalShares.add(totalLoot) > proposal.maxTotalSharesAndLootAtYesVote) {
-                proposal.maxTotalSharesAndLootAtYesVote = totalShares.add(totalLoot);
+            if ((totalShares + totalLoot) > proposal.maxTotalSharesAndLootAtYesVote) {
+                proposal.maxTotalSharesAndLootAtYesVote = totalShares + totalLoot;
             }
 
         } else if (vote == Vote.No) {
-            proposal.noVotes = proposal.noVotes.add(member.shares);
+            proposal.noVotes = proposal.noVotes + member.shares;
         }
      
         // NOTE: subgraph indexes by proposalId not proposalIndex since proposalIndex isn't set untill it's been sponsored but proposal is created on submission
@@ -616,7 +580,7 @@ contract Moloch is ReentrancyGuard {
         bool didPass = _didPass(proposalIndex);
 
         // Make the proposal fail if the new total number of shares and loot exceeds the limit
-        if (totalShares.add(totalLoot).add(proposal.sharesRequested).add(proposal.lootRequested) > MAX_NUMBER_OF_SHARES_AND_LOOT) {
+        if ((totalShares + totalLoot + proposal.sharesRequested + proposal.lootRequested) > MAX_NUMBER_OF_SHARES_AND_LOOT) {
             didPass = false;
         }
 
@@ -713,9 +677,9 @@ contract Moloch is ReentrancyGuard {
             member.jailed = proposalIndex;
 
             // transfer shares to loot
-            member.loot = member.loot.add(member.shares);
-            totalShares = totalShares.sub(member.shares);
-            totalLoot = totalLoot.add(member.shares);
+            member.loot = member.loot + member.shares;
+            totalShares = totalShares - member.shares;
+            totalLoot = totalLoot + member.shares;
             member.shares = 0; // revoke all shares
         }
 
@@ -732,7 +696,7 @@ contract Moloch is ReentrancyGuard {
         didPass = proposal.yesVotes > proposal.noVotes;
 
         // Make the proposal fail if the dilutionBound is exceeded
-        if ((totalShares.add(totalLoot)).mul(dilutionBound) < proposal.maxTotalSharesAndLootAtYesVote) {
+        if ((totalShares + totalLoot) * (dilutionBound) < proposal.maxTotalSharesAndLootAtYesVote) {
             didPass = false;
         }
 
@@ -750,14 +714,14 @@ contract Moloch is ReentrancyGuard {
         require(proposalIndex < proposalQueue.length, "proposal does not exist");
         Proposal memory proposal = proposals[proposalQueue[proposalIndex]];
 
-        require(getCurrentPeriod() >= proposal.startingPeriod.add(votingPeriodLength).add(gracePeriodLength), "proposal is not ready to be processed");
+        require(getCurrentPeriod() >= (proposal.startingPeriod + votingPeriodLength + gracePeriodLength), "proposal is not ready to be processed");
         require(proposal.flags[1] == false, "proposal has already been processed");
-        require(proposalIndex == 0 || proposals[proposalQueue[proposalIndex.sub(1)]].flags[1], "previous proposal must be processed");
+        require(proposalIndex == 0 || proposals[proposalQueue[proposalIndex - 1]].flags[1], "previous proposal must be processed");
     }
 
     function _returnDeposit(address sponsor) internal {
         unsafeInternalTransfer(ESCROW, msg.sender, depositToken, processingReward);
-        unsafeInternalTransfer(ESCROW, sponsor, depositToken, proposalDeposit.sub(processingReward));
+        unsafeInternalTransfer(ESCROW, sponsor, depositToken, proposalDeposit - processingReward);
     }
 
     function ragequit(uint256 sharesToBurn, uint256 lootToBurn) public nonReentrant onlyMember {
@@ -765,7 +729,7 @@ contract Moloch is ReentrancyGuard {
     }
 
     function _ragequit(address memberAddress, uint256 sharesToBurn, uint256 lootToBurn) internal {
-        uint256 initialTotalSharesAndLoot = totalShares.add(totalLoot);
+        uint256 initialTotalSharesAndLoot = totalShares + totalLoot;
 
         Member storage member = members[memberAddress];
 
@@ -774,7 +738,7 @@ contract Moloch is ReentrancyGuard {
 
         require(canRagequit(member.highestIndexYesVote), "cannot ragequit until highest index proposal member voted YES on is processed");
 
-        uint256 sharesAndLootToBurn = sharesToBurn.add(lootToBurn);
+        uint256 sharesAndLootToBurn = sharesToBurn + lootToBurn;
 
         // burn shares and loot
         _setSharesLoot(memberAddress, sharesToBurn, lootToBurn, false);
@@ -806,12 +770,12 @@ contract Moloch is ReentrancyGuard {
         _withdrawBalance(token, amount);
     }
 
-    function withdrawBalances(address[] memory tokens, uint256[] memory amounts, bool max) public nonReentrant {
+    function withdrawBalances(address[] memory tokens, uint256[] memory amounts, bool shouldWithdrawMax) public nonReentrant {
         require(tokens.length == amounts.length, "tokens and amounts arrays must be matching lengths");
 
         for (uint256 i=0; i < tokens.length; i++) {
             uint256 withdrawAmount = amounts[i];
-            if (max) { // withdraw the maximum balance
+            if (shouldWithdrawMax) { // withdraw the maximum balance
                 withdrawAmount = userTokenBalances[msg.sender][tokens[i]];
             }
 
@@ -827,7 +791,7 @@ contract Moloch is ReentrancyGuard {
     }
 
     function collectTokens(address token) public onlyDelegateOrShaman nonReentrant {
-        uint256 amountToCollect = IERC20(token).balanceOf(address(this)).sub(userTokenBalances[TOTAL][token]);
+        uint256 amountToCollect = IERC20(token).balanceOf(address(this)) - userTokenBalances[TOTAL][token];
         // only collect if 1) there are tokens to collect 2) token is whitelisted 3) token has non-zero balance
         require(amountToCollect > 0, 'no tokens to collect');
         require(tokenWhitelist[token], 'token to collect must be whitelisted');
@@ -878,7 +842,7 @@ contract Moloch is ReentrancyGuard {
     }
 
     function hasVotingPeriodExpired(uint256 startingPeriod) public view returns (bool) {
-        return getCurrentPeriod() >= startingPeriod.add(votingPeriodLength);
+        return getCurrentPeriod() >= (startingPeriod + votingPeriodLength);
     }
 
     /***************
@@ -889,7 +853,7 @@ contract Moloch is ReentrancyGuard {
     }
 
     function getCurrentPeriod() public view returns (uint256) {
-        return now.sub(summoningTime).div(periodDuration);
+        return (block.timestamp - summoningTime) / (periodDuration);
     }
 
     function getProposalQueueLength() public view returns (uint256) {
@@ -907,7 +871,7 @@ contract Moloch is ReentrancyGuard {
     function getMemberProposalVote(address memberAddress, uint256 proposalIndex) public view returns (Vote) {
         require(members[memberAddress].exists, "member does not exist");
         require(proposalIndex < proposalQueue.length, "proposal does not exist");
-        return proposals[proposalQueue[proposalIndex]].votesByMember[memberAddress];
+        return voteHistory[proposalIndex][memberAddress];
     }
 
     function getTokenCount() public view returns (uint256) {
@@ -987,7 +951,7 @@ contract MolochSummoner is CloneFactory {
 
     // Moloch private moloch; // moloch contract
 
-    constructor(address _template) public {
+    constructor(address _template) {
         template = _template;
     }
 
@@ -1035,7 +999,7 @@ contract MolochSummoner is CloneFactory {
             address(moloch),
             _shaman,
             _approvedTokens,
-            now,
+            block.timestamp,
             _periodDuration,
             _votingPeriodLength,
             _gracePeriodLength,

--- a/contracts/Wrapper.sol
+++ b/contracts/Wrapper.sol
@@ -18,7 +18,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.4;
 
 contract Wrapper {
     string public name     = "Wrapped Ether";

--- a/contracts/Wrapper.sol
+++ b/contracts/Wrapper.sol
@@ -17,7 +17,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-pragma solidity ^0.6.1;
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.0;
 
 contract Wrapper {
     string public name     = "Wrapped Ether";
@@ -32,6 +33,8 @@ contract Wrapper {
     mapping (address => uint)                       public  balanceOf;
     mapping (address => mapping (address => uint))  public  allowance;
 
+    uint256 internal constant MAX_INT = 2**256 - 1;
+
     receive() external payable {
         deposit();
     }
@@ -42,7 +45,7 @@ contract Wrapper {
     function withdraw(uint wad) public {
         require(balanceOf[msg.sender] >= wad);
         balanceOf[msg.sender] -= wad;
-        msg.sender.transfer(wad);
+        payable(msg.sender).transfer(wad);
         emit Withdrawal(msg.sender, wad);
     }
 
@@ -66,7 +69,7 @@ contract Wrapper {
     {
         require(balanceOf[src] >= wad);
 
-        if (src != msg.sender && allowance[src][msg.sender] != uint(-1)) {
+        if (src != msg.sender && allowance[src][msg.sender] != MAX_INT) {
             require(allowance[src][msg.sender] >= wad);
             allowance[src][msg.sender] -= wad;
         }

--- a/contracts/Yeeter.sol
+++ b/contracts/Yeeter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.4;
 
 import "./MolochSummoner.sol";
 import "./Wrapper.sol";

--- a/contracts/Yeeter.sol
+++ b/contracts/Yeeter.sol
@@ -1,4 +1,5 @@
-pragma solidity ^0.6.1;
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.0;
 
 import "./MolochSummoner.sol";
 import "./Wrapper.sol";
@@ -59,7 +60,7 @@ contract Yeeter {
         );
 
         // wrap
-        (bool success, ) = address(wrapper).call.value(newValue)("");
+        (bool success, ) = address(wrapper).call{value: newValue}("");
         require(success, "wrap failed");
         // send to dao
         require(
@@ -69,7 +70,7 @@ contract Yeeter {
 
         if (msg.value > newValue) {
             // Return the extra money to the minter.
-            (bool success2, ) = msg.sender.call.value(msg.value - newValue)("");
+            (bool success2, ) = msg.sender.call{value: msg.value - newValue}("");
             require(success2, "Transfer failed");
         }
 
@@ -110,7 +111,7 @@ contract YeetSummoner is CloneFactory {
 
     // Moloch private moloch; // moloch contract
 
-    constructor(address payable _template) public {
+    constructor(address payable _template) {
         template = _template;
     }
 

--- a/contracts/fixtures/GnosisImports.sol
+++ b/contracts/fixtures/GnosisImports.sol
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.0;
 
 import "@gnosis.pm/safe-contracts/contracts/GnosisSafe.sol"; //https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/access/Ownable.sol
 import "@gnosis.pm/safe-contracts/contracts/proxies/GnosisSafeProxyFactory.sol"; //https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/access/Ownable.sol

--- a/contracts/fixtures/GnosisImports.sol
+++ b/contracts/fixtures/GnosisImports.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.4;
 
 import "@gnosis.pm/safe-contracts/contracts/GnosisSafe.sol"; //https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/access/Ownable.sol
 import "@gnosis.pm/safe-contracts/contracts/proxies/GnosisSafeProxyFactory.sol"; //https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/access/Ownable.sol

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -113,7 +113,7 @@ const config: HardhatUserConfig = {
         }
       },
       {
-        version: "0.8.0",
+        version: "0.8.4",
         settings: {
           optimizer: {
             enabled: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,11 +25,11 @@
       "integrity": "sha512-JSvpj1iNMFjK6K+uVl4unqMoa9rf5jopb8cya5UGBWz23Nw8hSNT7efgUx4BTlAPAgpNlEioUfeTyQ6J9ZvTVw==",
       "dev": true,
       "requires": {
-        "bluebird": "3.7.2",
-        "eth-ens-namehash": "2.0.8",
-        "solc": "0.4.26",
+        "bluebird": "^3.5.2",
+        "eth-ens-namehash": "^2.0.8",
+        "solc": "^0.4.20",
         "testrpc": "0.0.1",
-        "web3-utils": "1.5.2"
+        "web3-utils": "^1.0.0-beta.31"
       }
     },
     "@ensdomains/resolver": {
@@ -44,8 +44,8 @@
       "integrity": "sha512-GVaFKuFbFUclMkhHtQTDnWBnBQMJc/pAbfbFj/nnIK237WPLsO3KDDslA7m+MNEyTAOFrcc0CyfruAGGXAQw3g==",
       "dev": true,
       "requires": {
-        "@ethereum-waffle/provider": "3.4.0",
-        "ethers": "5.4.6"
+        "@ethereum-waffle/provider": "^3.4.0",
+        "ethers": "^5.0.0"
       }
     },
     "@ethereum-waffle/compiler": {
@@ -54,17 +54,17 @@
       "integrity": "sha512-a2wxGOoB9F1QFRE+Om7Cz2wn+pxM/o7a0a6cbwhaS2lECJgFzeN9xEkVrKahRkF4gEfXGcuORg4msP0Asxezlw==",
       "dev": true,
       "requires": {
-        "@resolver-engine/imports": "0.3.3",
-        "@resolver-engine/imports-fs": "0.3.3",
-        "@typechain/ethers-v5": "2.0.0",
-        "@types/mkdirp": "0.5.2",
-        "@types/node-fetch": "2.5.12",
-        "ethers": "5.4.6",
-        "mkdirp": "0.5.5",
-        "node-fetch": "2.6.1",
-        "solc": "0.6.12",
-        "ts-generator": "0.1.1",
-        "typechain": "3.0.0"
+        "@resolver-engine/imports": "^0.3.3",
+        "@resolver-engine/imports-fs": "^0.3.3",
+        "@typechain/ethers-v5": "^2.0.0",
+        "@types/mkdirp": "^0.5.2",
+        "@types/node-fetch": "^2.5.5",
+        "ethers": "^5.0.1",
+        "mkdirp": "^0.5.1",
+        "node-fetch": "^2.6.1",
+        "solc": "^0.6.3",
+        "ts-generator": "^0.1.1",
+        "typechain": "^3.0.0"
       },
       "dependencies": {
         "fs-extra": {
@@ -73,11 +73,11 @@
           "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.2.8",
-            "jsonfile": "2.4.0",
-            "klaw": "1.3.1",
-            "path-is-absolute": "1.0.1",
-            "rimraf": "2.7.1"
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^2.1.0",
+            "klaw": "^1.0.0",
+            "path-is-absolute": "^1.0.0",
+            "rimraf": "^2.2.8"
           }
         },
         "js-sha3": {
@@ -92,7 +92,7 @@
           "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.2.8"
+            "graceful-fs": "^4.1.6"
           }
         },
         "require-from-string": {
@@ -113,13 +113,13 @@
           "integrity": "sha512-Lm0Ql2G9Qc7yPP2Ba+WNmzw2jwsrd3u4PobHYlSOxaut3TtUbj9+5ZrT6f4DUpNPEoBaFUOEg9Op9C0mk7ge9g==",
           "dev": true,
           "requires": {
-            "command-exists": "1.2.9",
+            "command-exists": "^1.2.8",
             "commander": "3.0.2",
-            "fs-extra": "0.30.0",
+            "fs-extra": "^0.30.0",
             "js-sha3": "0.8.0",
-            "memorystream": "0.3.1",
-            "require-from-string": "2.0.2",
-            "semver": "5.7.1",
+            "memorystream": "^0.3.1",
+            "require-from-string": "^2.0.0",
+            "semver": "^5.5.0",
             "tmp": "0.0.33"
           }
         }
@@ -131,9 +131,9 @@
       "integrity": "sha512-zVIH/5cQnIEgJPg1aV8+ehYicpcfuAisfrtzYh1pN3UbfeqPylFBeBaIZ7xj/xYzlJjkrek/h9VfULl6EX9Aqw==",
       "dev": true,
       "requires": {
-        "@ensdomains/ens": "0.4.5",
-        "@ensdomains/resolver": "0.2.4",
-        "ethers": "5.4.6"
+        "@ensdomains/ens": "^0.4.4",
+        "@ensdomains/resolver": "^0.2.4",
+        "ethers": "^5.0.1"
       }
     },
     "@ethereum-waffle/mock-contract": {
@@ -142,8 +142,8 @@
       "integrity": "sha512-apwq0d+2nQxaNwsyLkE+BNMBhZ1MKGV28BtI9WjD3QD2Ztdt1q9II4sKA4VrLTUneYSmkYbJZJxw89f+OpJGyw==",
       "dev": true,
       "requires": {
-        "@ethersproject/abi": "5.4.1",
-        "ethers": "5.4.6"
+        "@ethersproject/abi": "^5.0.1",
+        "ethers": "^5.0.1"
       }
     },
     "@ethereum-waffle/provider": {
@@ -152,11 +152,11 @@
       "integrity": "sha512-QgseGzpwlzmaHXhqfdzthCGu5a6P1SBF955jQHf/rBkK1Y7gGo2ukt3rXgxgfg/O5eHqRU+r8xw5MzVyVaBscQ==",
       "dev": true,
       "requires": {
-        "@ethereum-waffle/ens": "3.3.0",
-        "ethers": "5.4.6",
-        "ganache-core": "2.13.2",
-        "patch-package": "6.4.7",
-        "postinstall-postinstall": "2.1.0"
+        "@ethereum-waffle/ens": "^3.3.0",
+        "ethers": "^5.0.1",
+        "ganache-core": "^2.13.2",
+        "patch-package": "^6.2.2",
+        "postinstall-postinstall": "^2.1.0"
       }
     },
     "@ethereumjs/block": {
@@ -165,10 +165,10 @@
       "integrity": "sha512-umKAoTX32yXzErpIksPHodFc/5y8bmZMnOl6hWy5Vd8xId4+HKFUOyEiN16Y97zMwFRysRpcrR6wBejfqc6Bmg==",
       "dev": true,
       "requires": {
-        "@ethereumjs/common": "2.4.0",
-        "@ethereumjs/tx": "3.3.0",
-        "ethereumjs-util": "7.1.0",
-        "merkle-patricia-tree": "4.2.1"
+        "@ethereumjs/common": "^2.4.0",
+        "@ethereumjs/tx": "^3.3.0",
+        "ethereumjs-util": "^7.1.0",
+        "merkle-patricia-tree": "^4.2.0"
       }
     },
     "@ethereumjs/blockchain": {
@@ -177,15 +177,15 @@
       "integrity": "sha512-wAuKLaew6PL52kH8YPXO7PbjjKV12jivRSyHQehkESw4slSLLfYA6Jv7n5YxyT2ajD7KNMPVh7oyF/MU6HcOvg==",
       "dev": true,
       "requires": {
-        "@ethereumjs/block": "3.4.0",
-        "@ethereumjs/common": "2.4.0",
-        "@ethereumjs/ethash": "1.0.0",
-        "debug": "2.6.9",
-        "ethereumjs-util": "7.1.0",
-        "level-mem": "5.0.1",
-        "lru-cache": "5.1.1",
-        "rlp": "2.2.6",
-        "semaphore-async-await": "1.5.1"
+        "@ethereumjs/block": "^3.4.0",
+        "@ethereumjs/common": "^2.4.0",
+        "@ethereumjs/ethash": "^1.0.0",
+        "debug": "^2.2.0",
+        "ethereumjs-util": "^7.1.0",
+        "level-mem": "^5.0.1",
+        "lru-cache": "^5.1.1",
+        "rlp": "^2.2.4",
+        "semaphore-async-await": "^1.5.1"
       },
       "dependencies": {
         "debug": {
@@ -211,8 +211,8 @@
       "integrity": "sha512-UdkhFWzWcJCZVsj1O/H8/oqj/0RVYjLc1OhPjBrQdALAkQHpCp8xXI4WLnuGTADqTdJZww0NtgwG+TRPkXt27w==",
       "dev": true,
       "requires": {
-        "crc-32": "1.2.0",
-        "ethereumjs-util": "7.1.0"
+        "crc-32": "^1.2.0",
+        "ethereumjs-util": "^7.1.0"
       }
     },
     "@ethereumjs/ethash": {
@@ -221,10 +221,10 @@
       "integrity": "sha512-iIqnGG6NMKesyOxv2YctB2guOVX18qMAWlj3QlZyrc+GqfzLqoihti+cVNQnyNxr7eYuPdqwLQOFuPe6g/uKjw==",
       "dev": true,
       "requires": {
-        "@types/levelup": "4.3.3",
-        "buffer-xor": "2.0.2",
-        "ethereumjs-util": "7.1.0",
-        "miller-rabin": "4.0.1"
+        "@types/levelup": "^4.3.0",
+        "buffer-xor": "^2.0.1",
+        "ethereumjs-util": "^7.0.7",
+        "miller-rabin": "^4.0.0"
       },
       "dependencies": {
         "buffer-xor": {
@@ -233,7 +233,7 @@
           "integrity": "sha512-eHslX0bin3GB+Lx2p7lEYRShRewuNZL3fUl4qlVJGGiwoPGftmt8JQgk2Y9Ji5/01TnVDo33E5b5O3vUB1HdqQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.2.1"
+            "safe-buffer": "^5.1.1"
           }
         }
       }
@@ -244,8 +244,8 @@
       "integrity": "sha512-yTwEj2lVzSMgE6Hjw9Oa1DZks/nKTWM8Wn4ykDNapBPua2f4nXO3qKnni86O6lgDj5fVNRqbDsD0yy7/XNGDEA==",
       "dev": true,
       "requires": {
-        "@ethereumjs/common": "2.4.0",
-        "ethereumjs-util": "7.1.0"
+        "@ethereumjs/common": "^2.4.0",
+        "ethereumjs-util": "^7.1.0"
       }
     },
     "@ethereumjs/vm": {
@@ -254,19 +254,19 @@
       "integrity": "sha512-AydZ4wfvZAsBuFzs3xVSA2iU0hxhL8anXco3UW3oh9maVC34kTEytOfjHf06LTEfN0MF9LDQ4ciLa7If6ZN/sg==",
       "dev": true,
       "requires": {
-        "@ethereumjs/block": "3.4.0",
-        "@ethereumjs/blockchain": "5.4.0",
-        "@ethereumjs/common": "2.4.0",
-        "@ethereumjs/tx": "3.3.0",
-        "async-eventemitter": "0.2.4",
-        "core-js-pure": "3.17.2",
-        "debug": "2.6.9",
-        "ethereumjs-util": "7.1.0",
-        "functional-red-black-tree": "1.0.1",
-        "mcl-wasm": "0.7.9",
-        "merkle-patricia-tree": "4.2.1",
-        "rustbn.js": "0.2.0",
-        "util.promisify": "1.1.1"
+        "@ethereumjs/block": "^3.4.0",
+        "@ethereumjs/blockchain": "^5.4.0",
+        "@ethereumjs/common": "^2.4.0",
+        "@ethereumjs/tx": "^3.3.0",
+        "async-eventemitter": "^0.2.4",
+        "core-js-pure": "^3.0.1",
+        "debug": "^2.2.0",
+        "ethereumjs-util": "^7.1.0",
+        "functional-red-black-tree": "^1.0.1",
+        "mcl-wasm": "^0.7.1",
+        "merkle-patricia-tree": "^4.2.0",
+        "rustbn.js": "~0.2.0",
+        "util.promisify": "^1.0.1"
       },
       "dependencies": {
         "debug": {
@@ -292,15 +292,15 @@
       "integrity": "sha512-9mhbjUk76BiSluiiW4BaYyI58KSbDMMQpCLdsAR+RsT2GyATiNYxVv+pGWRrekmsIdY3I+hOqsYQSTkc8L/mcg==",
       "dev": true,
       "requires": {
-        "@ethersproject/address": "5.4.0",
-        "@ethersproject/bignumber": "5.4.1",
-        "@ethersproject/bytes": "5.4.0",
-        "@ethersproject/constants": "5.4.0",
-        "@ethersproject/hash": "5.4.0",
-        "@ethersproject/keccak256": "5.4.0",
-        "@ethersproject/logger": "5.4.1",
-        "@ethersproject/properties": "5.4.1",
-        "@ethersproject/strings": "5.4.0"
+        "@ethersproject/address": "^5.4.0",
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/constants": "^5.4.0",
+        "@ethersproject/hash": "^5.4.0",
+        "@ethersproject/keccak256": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/strings": "^5.4.0"
       }
     },
     "@ethersproject/abstract-provider": {
@@ -309,13 +309,13 @@
       "integrity": "sha512-3EedfKI3LVpjSKgAxoUaI+gB27frKsxzm+r21w9G60Ugk+3wVLQwhi1LsEJAKNV7WoZc8CIpNrATlL1QFABjtQ==",
       "dev": true,
       "requires": {
-        "@ethersproject/bignumber": "5.4.1",
-        "@ethersproject/bytes": "5.4.0",
-        "@ethersproject/logger": "5.4.1",
-        "@ethersproject/networks": "5.4.2",
-        "@ethersproject/properties": "5.4.1",
-        "@ethersproject/transactions": "5.4.0",
-        "@ethersproject/web": "5.4.0"
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/networks": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/transactions": "^5.4.0",
+        "@ethersproject/web": "^5.4.0"
       }
     },
     "@ethersproject/abstract-signer": {
@@ -324,11 +324,11 @@
       "integrity": "sha512-SkkFL5HVq1k4/25dM+NWP9MILgohJCgGv5xT5AcRruGz4ILpfHeBtO/y6j+Z3UN/PAjDeb4P7E51Yh8wcGNLGA==",
       "dev": true,
       "requires": {
-        "@ethersproject/abstract-provider": "5.4.1",
-        "@ethersproject/bignumber": "5.4.1",
-        "@ethersproject/bytes": "5.4.0",
-        "@ethersproject/logger": "5.4.1",
-        "@ethersproject/properties": "5.4.1"
+        "@ethersproject/abstract-provider": "^5.4.0",
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0"
       }
     },
     "@ethersproject/address": {
@@ -337,11 +337,11 @@
       "integrity": "sha512-SD0VgOEkcACEG/C6xavlU1Hy3m5DGSXW3CUHkaaEHbAPPsgi0coP5oNPsxau8eTlZOk/bpa/hKeCNoK5IzVI2Q==",
       "dev": true,
       "requires": {
-        "@ethersproject/bignumber": "5.4.1",
-        "@ethersproject/bytes": "5.4.0",
-        "@ethersproject/keccak256": "5.4.0",
-        "@ethersproject/logger": "5.4.1",
-        "@ethersproject/rlp": "5.4.0"
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/keccak256": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/rlp": "^5.4.0"
       }
     },
     "@ethersproject/base64": {
@@ -350,7 +350,7 @@
       "integrity": "sha512-CjQw6E17QDSSC5jiM9YpF7N1aSCHmYGMt9bWD8PWv6YPMxjsys2/Q8xLrROKI3IWJ7sFfZ8B3flKDTM5wlWuZQ==",
       "dev": true,
       "requires": {
-        "@ethersproject/bytes": "5.4.0"
+        "@ethersproject/bytes": "^5.4.0"
       }
     },
     "@ethersproject/basex": {
@@ -359,8 +359,8 @@
       "integrity": "sha512-J07+QCVJ7np2bcpxydFVf/CuYo9mZ7T73Pe7KQY4c1lRlrixMeblauMxHXD0MPwFmUHZIILDNViVkykFBZylbg==",
       "dev": true,
       "requires": {
-        "@ethersproject/bytes": "5.4.0",
-        "@ethersproject/properties": "5.4.1"
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0"
       }
     },
     "@ethersproject/bignumber": {
@@ -369,9 +369,9 @@
       "integrity": "sha512-fJhdxqoQNuDOk6epfM7yD6J8Pol4NUCy1vkaGAkuujZm0+lNow//MKu1hLhRiYV4BsOHyBv5/lsTjF+7hWwhJg==",
       "dev": true,
       "requires": {
-        "@ethersproject/bytes": "5.4.0",
-        "@ethersproject/logger": "5.4.1",
-        "bn.js": "4.12.0"
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "bn.js": "^4.11.9"
       }
     },
     "@ethersproject/bytes": {
@@ -380,7 +380,7 @@
       "integrity": "sha512-H60ceqgTHbhzOj4uRc/83SCN9d+BSUnOkrr2intevqdtEMO1JFVZ1XL84OEZV+QjV36OaZYxtnt4lGmxcGsPfA==",
       "dev": true,
       "requires": {
-        "@ethersproject/logger": "5.4.1"
+        "@ethersproject/logger": "^5.4.0"
       }
     },
     "@ethersproject/constants": {
@@ -389,7 +389,7 @@
       "integrity": "sha512-tzjn6S7sj9+DIIeKTJLjK9WGN2Tj0P++Z8ONEIlZjyoTkBuODN+0VfhAyYksKi43l1Sx9tX2VlFfzjfmr5Wl3Q==",
       "dev": true,
       "requires": {
-        "@ethersproject/bignumber": "5.4.1"
+        "@ethersproject/bignumber": "^5.4.0"
       }
     },
     "@ethersproject/contracts": {
@@ -398,16 +398,16 @@
       "integrity": "sha512-m+z2ZgPy4pyR15Je//dUaymRUZq5MtDajF6GwFbGAVmKz/RF+DNIPwF0k5qEcL3wPGVqUjFg2/krlCRVTU4T5w==",
       "dev": true,
       "requires": {
-        "@ethersproject/abi": "5.4.1",
-        "@ethersproject/abstract-provider": "5.4.1",
-        "@ethersproject/abstract-signer": "5.4.1",
-        "@ethersproject/address": "5.4.0",
-        "@ethersproject/bignumber": "5.4.1",
-        "@ethersproject/bytes": "5.4.0",
-        "@ethersproject/constants": "5.4.0",
-        "@ethersproject/logger": "5.4.1",
-        "@ethersproject/properties": "5.4.1",
-        "@ethersproject/transactions": "5.4.0"
+        "@ethersproject/abi": "^5.4.0",
+        "@ethersproject/abstract-provider": "^5.4.0",
+        "@ethersproject/abstract-signer": "^5.4.0",
+        "@ethersproject/address": "^5.4.0",
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/constants": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/transactions": "^5.4.0"
       }
     },
     "@ethersproject/hash": {
@@ -416,14 +416,14 @@
       "integrity": "sha512-xymAM9tmikKgbktOCjW60Z5sdouiIIurkZUr9oW5NOex5uwxrbsYG09kb5bMcNjlVeJD3yPivTNzViIs1GCbqA==",
       "dev": true,
       "requires": {
-        "@ethersproject/abstract-signer": "5.4.1",
-        "@ethersproject/address": "5.4.0",
-        "@ethersproject/bignumber": "5.4.1",
-        "@ethersproject/bytes": "5.4.0",
-        "@ethersproject/keccak256": "5.4.0",
-        "@ethersproject/logger": "5.4.1",
-        "@ethersproject/properties": "5.4.1",
-        "@ethersproject/strings": "5.4.0"
+        "@ethersproject/abstract-signer": "^5.4.0",
+        "@ethersproject/address": "^5.4.0",
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/keccak256": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/strings": "^5.4.0"
       }
     },
     "@ethersproject/hdnode": {
@@ -432,18 +432,18 @@
       "integrity": "sha512-pKxdS0KAaeVGfZPp1KOiDLB0jba11tG6OP1u11QnYfb7pXn6IZx0xceqWRr6ygke8+Kw74IpOoSi7/DwANhy8Q==",
       "dev": true,
       "requires": {
-        "@ethersproject/abstract-signer": "5.4.1",
-        "@ethersproject/basex": "5.4.0",
-        "@ethersproject/bignumber": "5.4.1",
-        "@ethersproject/bytes": "5.4.0",
-        "@ethersproject/logger": "5.4.1",
-        "@ethersproject/pbkdf2": "5.4.0",
-        "@ethersproject/properties": "5.4.1",
-        "@ethersproject/sha2": "5.4.0",
-        "@ethersproject/signing-key": "5.4.0",
-        "@ethersproject/strings": "5.4.0",
-        "@ethersproject/transactions": "5.4.0",
-        "@ethersproject/wordlists": "5.4.0"
+        "@ethersproject/abstract-signer": "^5.4.0",
+        "@ethersproject/basex": "^5.4.0",
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/pbkdf2": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/sha2": "^5.4.0",
+        "@ethersproject/signing-key": "^5.4.0",
+        "@ethersproject/strings": "^5.4.0",
+        "@ethersproject/transactions": "^5.4.0",
+        "@ethersproject/wordlists": "^5.4.0"
       }
     },
     "@ethersproject/json-wallets": {
@@ -452,17 +452,17 @@
       "integrity": "sha512-igWcu3fx4aiczrzEHwG1xJZo9l1cFfQOWzTqwRw/xcvxTk58q4f9M7cjh51EKphMHvrJtcezJ1gf1q1AUOfEQQ==",
       "dev": true,
       "requires": {
-        "@ethersproject/abstract-signer": "5.4.1",
-        "@ethersproject/address": "5.4.0",
-        "@ethersproject/bytes": "5.4.0",
-        "@ethersproject/hdnode": "5.4.0",
-        "@ethersproject/keccak256": "5.4.0",
-        "@ethersproject/logger": "5.4.1",
-        "@ethersproject/pbkdf2": "5.4.0",
-        "@ethersproject/properties": "5.4.1",
-        "@ethersproject/random": "5.4.0",
-        "@ethersproject/strings": "5.4.0",
-        "@ethersproject/transactions": "5.4.0",
+        "@ethersproject/abstract-signer": "^5.4.0",
+        "@ethersproject/address": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/hdnode": "^5.4.0",
+        "@ethersproject/keccak256": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/pbkdf2": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/random": "^5.4.0",
+        "@ethersproject/strings": "^5.4.0",
+        "@ethersproject/transactions": "^5.4.0",
         "aes-js": "3.0.0",
         "scrypt-js": "3.0.1"
       }
@@ -473,7 +473,7 @@
       "integrity": "sha512-FBI1plWet+dPUvAzPAeHzRKiPpETQzqSUWR1wXJGHVWi4i8bOSrpC3NwpkPjgeXG7MnugVc1B42VbfnQikyC/A==",
       "dev": true,
       "requires": {
-        "@ethersproject/bytes": "5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
         "js-sha3": "0.5.7"
       }
     },
@@ -489,7 +489,7 @@
       "integrity": "sha512-eekOhvJyBnuibfJnhtK46b8HimBc5+4gqpvd1/H9LEl7Q7/qhsIhM81dI9Fcnjpk3jB1aTy6bj0hz3cifhNeYw==",
       "dev": true,
       "requires": {
-        "@ethersproject/logger": "5.4.1"
+        "@ethersproject/logger": "^5.4.0"
       }
     },
     "@ethersproject/pbkdf2": {
@@ -498,8 +498,8 @@
       "integrity": "sha512-x94aIv6tiA04g6BnazZSLoRXqyusawRyZWlUhKip2jvoLpzJuLb//KtMM6PEovE47pMbW+Qe1uw+68ameJjB7g==",
       "dev": true,
       "requires": {
-        "@ethersproject/bytes": "5.4.0",
-        "@ethersproject/sha2": "5.4.0"
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/sha2": "^5.4.0"
       }
     },
     "@ethersproject/properties": {
@@ -508,7 +508,7 @@
       "integrity": "sha512-cyCGlF8wWlIZyizsj2PpbJ9I7rIlUAfnHYwy/T90pdkSn/NFTa5YWZx2wTJBe9V7dD65dcrrEMisCRUJiq6n3w==",
       "dev": true,
       "requires": {
-        "@ethersproject/logger": "5.4.1"
+        "@ethersproject/logger": "^5.4.0"
       }
     },
     "@ethersproject/providers": {
@@ -517,23 +517,23 @@
       "integrity": "sha512-1GkrvkiAw3Fj28cwi1Sqm8ED1RtERtpdXmRfwIBGmqBSN5MoeRUHuwHPppMtbPayPgpFcvD7/Gdc9doO5fGYgw==",
       "dev": true,
       "requires": {
-        "@ethersproject/abstract-provider": "5.4.1",
-        "@ethersproject/abstract-signer": "5.4.1",
-        "@ethersproject/address": "5.4.0",
-        "@ethersproject/basex": "5.4.0",
-        "@ethersproject/bignumber": "5.4.1",
-        "@ethersproject/bytes": "5.4.0",
-        "@ethersproject/constants": "5.4.0",
-        "@ethersproject/hash": "5.4.0",
-        "@ethersproject/logger": "5.4.1",
-        "@ethersproject/networks": "5.4.2",
-        "@ethersproject/properties": "5.4.1",
-        "@ethersproject/random": "5.4.0",
-        "@ethersproject/rlp": "5.4.0",
-        "@ethersproject/sha2": "5.4.0",
-        "@ethersproject/strings": "5.4.0",
-        "@ethersproject/transactions": "5.4.0",
-        "@ethersproject/web": "5.4.0",
+        "@ethersproject/abstract-provider": "^5.4.0",
+        "@ethersproject/abstract-signer": "^5.4.0",
+        "@ethersproject/address": "^5.4.0",
+        "@ethersproject/basex": "^5.4.0",
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/constants": "^5.4.0",
+        "@ethersproject/hash": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/networks": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/random": "^5.4.0",
+        "@ethersproject/rlp": "^5.4.0",
+        "@ethersproject/sha2": "^5.4.0",
+        "@ethersproject/strings": "^5.4.0",
+        "@ethersproject/transactions": "^5.4.0",
+        "@ethersproject/web": "^5.4.0",
         "bech32": "1.1.4",
         "ws": "7.4.6"
       }
@@ -544,8 +544,8 @@
       "integrity": "sha512-pnpWNQlf0VAZDEOVp1rsYQosmv2o0ITS/PecNw+mS2/btF8eYdspkN0vIXrCMtkX09EAh9bdk8GoXmFXM1eAKw==",
       "dev": true,
       "requires": {
-        "@ethersproject/bytes": "5.4.0",
-        "@ethersproject/logger": "5.4.1"
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0"
       }
     },
     "@ethersproject/rlp": {
@@ -554,8 +554,8 @@
       "integrity": "sha512-0I7MZKfi+T5+G8atId9QaQKHRvvasM/kqLyAH4XxBCBchAooH2EX5rL9kYZWwcm3awYV+XC7VF6nLhfeQFKVPg==",
       "dev": true,
       "requires": {
-        "@ethersproject/bytes": "5.4.0",
-        "@ethersproject/logger": "5.4.1"
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0"
       }
     },
     "@ethersproject/sha2": {
@@ -564,8 +564,8 @@
       "integrity": "sha512-siheo36r1WD7Cy+bDdE1BJ8y0bDtqXCOxRMzPa4bV1TGt/eTUUt03BHoJNB6reWJD8A30E/pdJ8WFkq+/uz4Gg==",
       "dev": true,
       "requires": {
-        "@ethersproject/bytes": "5.4.0",
-        "@ethersproject/logger": "5.4.1",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
         "hash.js": "1.1.7"
       }
     },
@@ -575,10 +575,10 @@
       "integrity": "sha512-q8POUeywx6AKg2/jX9qBYZIAmKSB4ubGXdQ88l40hmATj29JnG5pp331nAWwwxPn2Qao4JpWHNZsQN+bPiSW9A==",
       "dev": true,
       "requires": {
-        "@ethersproject/bytes": "5.4.0",
-        "@ethersproject/logger": "5.4.1",
-        "@ethersproject/properties": "5.4.1",
-        "bn.js": "4.12.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "bn.js": "^4.11.9",
         "elliptic": "6.5.4",
         "hash.js": "1.1.7"
       }
@@ -589,11 +589,11 @@
       "integrity": "sha512-XFQTZ7wFSHOhHcV1DpcWj7VXECEiSrBuv7JErJvB9Uo+KfCdc3QtUZV+Vjh/AAaYgezUEKbCtE6Khjm44seevQ==",
       "dev": true,
       "requires": {
-        "@ethersproject/bignumber": "5.4.1",
-        "@ethersproject/bytes": "5.4.0",
-        "@ethersproject/keccak256": "5.4.0",
-        "@ethersproject/sha2": "5.4.0",
-        "@ethersproject/strings": "5.4.0"
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/keccak256": "^5.4.0",
+        "@ethersproject/sha2": "^5.4.0",
+        "@ethersproject/strings": "^5.4.0"
       }
     },
     "@ethersproject/strings": {
@@ -602,9 +602,9 @@
       "integrity": "sha512-k/9DkH5UGDhv7aReXLluFG5ExurwtIpUfnDNhQA29w896Dw3i4uDTz01Quaptbks1Uj9kI8wo9tmW73wcIEaWA==",
       "dev": true,
       "requires": {
-        "@ethersproject/bytes": "5.4.0",
-        "@ethersproject/constants": "5.4.0",
-        "@ethersproject/logger": "5.4.1"
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/constants": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0"
       }
     },
     "@ethersproject/transactions": {
@@ -613,15 +613,15 @@
       "integrity": "sha512-s3EjZZt7xa4BkLknJZ98QGoIza94rVjaEed0rzZ/jB9WrIuu/1+tjvYCWzVrystXtDswy7TPBeIepyXwSYa4WQ==",
       "dev": true,
       "requires": {
-        "@ethersproject/address": "5.4.0",
-        "@ethersproject/bignumber": "5.4.1",
-        "@ethersproject/bytes": "5.4.0",
-        "@ethersproject/constants": "5.4.0",
-        "@ethersproject/keccak256": "5.4.0",
-        "@ethersproject/logger": "5.4.1",
-        "@ethersproject/properties": "5.4.1",
-        "@ethersproject/rlp": "5.4.0",
-        "@ethersproject/signing-key": "5.4.0"
+        "@ethersproject/address": "^5.4.0",
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/constants": "^5.4.0",
+        "@ethersproject/keccak256": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/rlp": "^5.4.0",
+        "@ethersproject/signing-key": "^5.4.0"
       }
     },
     "@ethersproject/units": {
@@ -630,9 +630,9 @@
       "integrity": "sha512-Z88krX40KCp+JqPCP5oPv5p750g+uU6gopDYRTBGcDvOASh6qhiEYCRatuM/suC4S2XW9Zz90QI35MfSrTIaFg==",
       "dev": true,
       "requires": {
-        "@ethersproject/bignumber": "5.4.1",
-        "@ethersproject/constants": "5.4.0",
-        "@ethersproject/logger": "5.4.1"
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/constants": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0"
       }
     },
     "@ethersproject/wallet": {
@@ -641,21 +641,21 @@
       "integrity": "sha512-wU29majLjM6AjCjpat21mPPviG+EpK7wY1+jzKD0fg3ui5fgedf2zEu1RDgpfIMsfn8fJHJuzM4zXZ2+hSHaSQ==",
       "dev": true,
       "requires": {
-        "@ethersproject/abstract-provider": "5.4.1",
-        "@ethersproject/abstract-signer": "5.4.1",
-        "@ethersproject/address": "5.4.0",
-        "@ethersproject/bignumber": "5.4.1",
-        "@ethersproject/bytes": "5.4.0",
-        "@ethersproject/hash": "5.4.0",
-        "@ethersproject/hdnode": "5.4.0",
-        "@ethersproject/json-wallets": "5.4.0",
-        "@ethersproject/keccak256": "5.4.0",
-        "@ethersproject/logger": "5.4.1",
-        "@ethersproject/properties": "5.4.1",
-        "@ethersproject/random": "5.4.0",
-        "@ethersproject/signing-key": "5.4.0",
-        "@ethersproject/transactions": "5.4.0",
-        "@ethersproject/wordlists": "5.4.0"
+        "@ethersproject/abstract-provider": "^5.4.0",
+        "@ethersproject/abstract-signer": "^5.4.0",
+        "@ethersproject/address": "^5.4.0",
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/hash": "^5.4.0",
+        "@ethersproject/hdnode": "^5.4.0",
+        "@ethersproject/json-wallets": "^5.4.0",
+        "@ethersproject/keccak256": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/random": "^5.4.0",
+        "@ethersproject/signing-key": "^5.4.0",
+        "@ethersproject/transactions": "^5.4.0",
+        "@ethersproject/wordlists": "^5.4.0"
       }
     },
     "@ethersproject/web": {
@@ -664,11 +664,11 @@
       "integrity": "sha512-1bUusGmcoRLYgMn6c1BLk1tOKUIFuTg8j+6N8lYlbMpDesnle+i3pGSagGNvwjaiLo4Y5gBibwctpPRmjrh4Og==",
       "dev": true,
       "requires": {
-        "@ethersproject/base64": "5.4.0",
-        "@ethersproject/bytes": "5.4.0",
-        "@ethersproject/logger": "5.4.1",
-        "@ethersproject/properties": "5.4.1",
-        "@ethersproject/strings": "5.4.0"
+        "@ethersproject/base64": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/strings": "^5.4.0"
       }
     },
     "@ethersproject/wordlists": {
@@ -677,11 +677,11 @@
       "integrity": "sha512-FemEkf6a+EBKEPxlzeVgUaVSodU7G0Na89jqKjmWMlDB0tomoU8RlEMgUvXyqtrg8N4cwpLh8nyRnm1Nay1isA==",
       "dev": true,
       "requires": {
-        "@ethersproject/bytes": "5.4.0",
-        "@ethersproject/hash": "5.4.0",
-        "@ethersproject/logger": "5.4.1",
-        "@ethersproject/properties": "5.4.1",
-        "@ethersproject/strings": "5.4.0"
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/hash": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/strings": "^5.4.0"
       }
     },
     "@gnosis.pm/safe-contracts": {
@@ -701,13 +701,13 @@
       "integrity": "sha512-gCvT5fj8GbXS9+ACS3BzrX0pzYHHZqAHCb+NcipOkl2cy48FakUXlzrCf4P4sTH+Y7W10OgT62ezD1sJ+/NikQ==",
       "dev": true,
       "requires": {
-        "@ethersproject/abi": "5.4.1",
-        "@ethersproject/address": "5.4.0",
-        "cbor": "5.2.0",
-        "debug": "4.3.2",
-        "fs-extra": "7.0.1",
-        "node-fetch": "2.6.1",
-        "semver": "6.3.0"
+        "@ethersproject/abi": "^5.1.2",
+        "@ethersproject/address": "^5.0.2",
+        "cbor": "^5.0.2",
+        "debug": "^4.1.1",
+        "fs-extra": "^7.0.1",
+        "node-fetch": "^2.6.0",
+        "semver": "^6.3.0"
       }
     },
     "@nomiclabs/hardhat-waffle": {
@@ -716,7 +716,7 @@
       "integrity": "sha512-2YR2V5zTiztSH9n8BYWgtv3Q+EL0N5Ltm1PAr5z20uAY4SkkfylJ98CIqt18XFvxTD5x4K2wKBzddjV9ViDAZQ==",
       "dev": true,
       "requires": {
-        "@types/sinon-chai": "3.2.5",
+        "@types/sinon-chai": "^3.2.3",
         "@types/web3": "1.0.19"
       }
     },
@@ -737,9 +737,9 @@
       "integrity": "sha512-eB8nEbKDJJBi5p5SrvrvILn4a0h42bKtbCTri3ZxCGt6UvoQyp7HnGOfki944bUjBSHKK3RvgfViHn+kqdXtnQ==",
       "dev": true,
       "requires": {
-        "debug": "3.2.7",
-        "is-url": "1.2.4",
-        "request": "2.88.2"
+        "debug": "^3.1.0",
+        "is-url": "^1.2.4",
+        "request": "^2.85.0"
       },
       "dependencies": {
         "debug": {
@@ -748,7 +748,7 @@
           "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
           "dev": true,
           "requires": {
-            "ms": "2.1.2"
+            "ms": "^2.1.1"
           }
         }
       }
@@ -759,8 +759,8 @@
       "integrity": "sha512-wQ9RhPUcny02Wm0IuJwYMyAG8fXVeKdmhm8xizNByD4ryZlx6PP6kRen+t/haF43cMfmaV7T3Cx6ChOdHEhFUQ==",
       "dev": true,
       "requires": {
-        "@resolver-engine/core": "0.3.3",
-        "debug": "3.2.7"
+        "@resolver-engine/core": "^0.3.3",
+        "debug": "^3.1.0"
       },
       "dependencies": {
         "debug": {
@@ -769,7 +769,7 @@
           "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
           "dev": true,
           "requires": {
-            "ms": "2.1.2"
+            "ms": "^2.1.1"
           }
         }
       }
@@ -780,11 +780,11 @@
       "integrity": "sha512-anHpS4wN4sRMwsAbMXhMfOD/y4a4Oo0Cw/5+rue7hSwGWsDOQaAU1ClK1OxjUC35/peazxEl8JaSRRS+Xb8t3Q==",
       "dev": true,
       "requires": {
-        "@resolver-engine/core": "0.3.3",
-        "debug": "3.2.7",
-        "hosted-git-info": "2.8.9",
-        "path-browserify": "1.0.1",
-        "url": "0.11.0"
+        "@resolver-engine/core": "^0.3.3",
+        "debug": "^3.1.0",
+        "hosted-git-info": "^2.6.0",
+        "path-browserify": "^1.0.0",
+        "url": "^0.11.0"
       },
       "dependencies": {
         "debug": {
@@ -793,7 +793,7 @@
           "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
           "dev": true,
           "requires": {
-            "ms": "2.1.2"
+            "ms": "^2.1.1"
           }
         }
       }
@@ -804,9 +804,9 @@
       "integrity": "sha512-7Pjg/ZAZtxpeyCFlZR5zqYkz+Wdo84ugB5LApwriT8XFeQoLwGUj4tZFFvvCuxaNCcqZzCYbonJgmGObYBzyCA==",
       "dev": true,
       "requires": {
-        "@resolver-engine/fs": "0.3.3",
-        "@resolver-engine/imports": "0.3.3",
-        "debug": "3.2.7"
+        "@resolver-engine/fs": "^0.3.3",
+        "@resolver-engine/imports": "^0.3.3",
+        "debug": "^3.1.0"
       },
       "dependencies": {
         "debug": {
@@ -815,7 +815,7 @@
           "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
           "dev": true,
           "requires": {
-            "ms": "2.1.2"
+            "ms": "^2.1.1"
           }
         }
       }
@@ -830,7 +830,7 @@
         "@sentry/minimal": "5.30.0",
         "@sentry/types": "5.30.0",
         "@sentry/utils": "5.30.0",
-        "tslib": "1.14.1"
+        "tslib": "^1.9.3"
       }
     },
     "@sentry/hub": {
@@ -841,7 +841,7 @@
       "requires": {
         "@sentry/types": "5.30.0",
         "@sentry/utils": "5.30.0",
-        "tslib": "1.14.1"
+        "tslib": "^1.9.3"
       }
     },
     "@sentry/minimal": {
@@ -852,7 +852,7 @@
       "requires": {
         "@sentry/hub": "5.30.0",
         "@sentry/types": "5.30.0",
-        "tslib": "1.14.1"
+        "tslib": "^1.9.3"
       }
     },
     "@sentry/node": {
@@ -866,10 +866,10 @@
         "@sentry/tracing": "5.30.0",
         "@sentry/types": "5.30.0",
         "@sentry/utils": "5.30.0",
-        "cookie": "0.4.1",
-        "https-proxy-agent": "5.0.0",
-        "lru_map": "0.3.3",
-        "tslib": "1.14.1"
+        "cookie": "^0.4.1",
+        "https-proxy-agent": "^5.0.0",
+        "lru_map": "^0.3.3",
+        "tslib": "^1.9.3"
       }
     },
     "@sentry/tracing": {
@@ -882,7 +882,7 @@
         "@sentry/minimal": "5.30.0",
         "@sentry/types": "5.30.0",
         "@sentry/utils": "5.30.0",
-        "tslib": "1.14.1"
+        "tslib": "^1.9.3"
       }
     },
     "@sentry/types": {
@@ -898,7 +898,7 @@
       "dev": true,
       "requires": {
         "@sentry/types": "5.30.0",
-        "tslib": "1.14.1"
+        "tslib": "^1.9.3"
       }
     },
     "@sinonjs/commons": {
@@ -916,7 +916,7 @@
       "integrity": "sha512-iQADsW4LBMISqZ6Ci1dupJL9pprqwcVFTcOsEmQOEhW+KLCVn/Y4Jrvg2k19fIHCp+iFprriYPTdRcQR8NbUPg==",
       "dev": true,
       "requires": {
-        "@sinonjs/commons": "1.8.3"
+        "@sinonjs/commons": "^1.7.0"
       }
     },
     "@solidity-parser/parser": {
@@ -955,7 +955,7 @@
       "integrity": "sha512-0xdCkyGOzdqh4h5JSf+zoWx85IusEjDcPIwNEHP8mrWSnCae4rvrqB+/gtpdNfX7zjlFlZiMeePn2r63EI3Lrw==",
       "dev": true,
       "requires": {
-        "ethers": "5.4.6"
+        "ethers": "^5.0.2"
       }
     },
     "@types/abstract-leveldown": {
@@ -970,7 +970,7 @@
       "integrity": "sha512-QSSVYj7pYFN49kW77o2s9xTCwZ8F2xLbjLLSEVh8D2F4JUhZtPAGOFLTD+ffqksBx/u4cE/KImFjyhqCjn/LIA==",
       "dev": true,
       "requires": {
-        "@types/node": "15.14.9"
+        "@types/node": "*"
       }
     },
     "@types/chai": {
@@ -985,7 +985,7 @@
       "integrity": "sha512-eHE4cQPoj6ngxBZMvVf6Hw7Mh4jMW4U9lpGmS5GBPB9RYxlFg+CHaVN7ErNY4W9XfLIEn20b4VDYaIrbq0q4uA==",
       "dev": true,
       "requires": {
-        "@types/node": "15.14.9"
+        "@types/node": "*"
       }
     },
     "@types/form-data": {
@@ -994,7 +994,7 @@
       "integrity": "sha1-yayFsqX9GENbjIXZ7LUObWyJP/g=",
       "dev": true,
       "requires": {
-        "@types/node": "15.14.9"
+        "@types/node": "*"
       }
     },
     "@types/level-errors": {
@@ -1009,9 +1009,9 @@
       "integrity": "sha512-K+OTIjJcZHVlZQN1HmU64VtrC0jC3dXWQozuEIR9zVvltIk90zaGPM2AgT+fIkChpzHhFE3YnvFLCbLtzAmexA==",
       "dev": true,
       "requires": {
-        "@types/abstract-leveldown": "5.0.2",
-        "@types/level-errors": "3.0.0",
-        "@types/node": "15.14.9"
+        "@types/abstract-leveldown": "*",
+        "@types/level-errors": "*",
+        "@types/node": "*"
       }
     },
     "@types/lru-cache": {
@@ -1026,7 +1026,7 @@
       "integrity": "sha512-U5icWpv7YnZYGsN4/cmh3WD2onMY0aJIiTE6+51TwJCttdHvtCYmkBNOobHlXwrJRL0nkH9jH4kD+1FAdMN4Tg==",
       "dev": true,
       "requires": {
-        "@types/node": "15.14.9"
+        "@types/node": "*"
       }
     },
     "@types/mocha": {
@@ -1047,8 +1047,8 @@
       "integrity": "sha512-MKgC4dlq4kKNa/mYrwpKfzQMB5X3ee5U6fSprkKpToBqBmX4nFZL9cW5jl6sWn+xpRJ7ypWh2yyqqr8UUCstSw==",
       "dev": true,
       "requires": {
-        "@types/node": "15.14.9",
-        "form-data": "3.0.1"
+        "@types/node": "*",
+        "form-data": "^3.0.0"
       },
       "dependencies": {
         "form-data": {
@@ -1057,9 +1057,9 @@
           "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
           "dev": true,
           "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.8",
-            "mime-types": "2.1.32"
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
           }
         }
       }
@@ -1070,7 +1070,7 @@
       "integrity": "sha512-Cf63Rv7jCQ0LaL8tNXmEyqTHuIJxRdlS5vMh1mj5voN4+QFhVZnlZruezqpWYDiJ8UTzhP0VmeLXCmBk66YrMQ==",
       "dev": true,
       "requires": {
-        "@types/node": "15.14.9"
+        "@types/node": "*"
       }
     },
     "@types/prettier": {
@@ -1091,7 +1091,7 @@
       "integrity": "sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==",
       "dev": true,
       "requires": {
-        "@types/node": "15.14.9"
+        "@types/node": "*"
       }
     },
     "@types/secp256k1": {
@@ -1100,7 +1100,7 @@
       "integrity": "sha512-Da66lEIFeIz9ltsdMZcpQvmrmmoqrfju8pm1BH8WbYjZSwUgCwXLb9C+9XYogwBITnbsSaMdVPb2ekf7TV+03w==",
       "dev": true,
       "requires": {
-        "@types/node": "15.14.9"
+        "@types/node": "*"
       }
     },
     "@types/sinon": {
@@ -1109,7 +1109,7 @@
       "integrity": "sha512-BHn8Bpkapj8Wdfxvh2jWIUoaYB/9/XhsL0oOvBfRagJtKlSl9NWPcFOz2lRukI9szwGxFtYZCTejJSqsGDbdmw==",
       "dev": true,
       "requires": {
-        "@sinonjs/fake-timers": "7.1.2"
+        "@sinonjs/fake-timers": "^7.1.0"
       }
     },
     "@types/sinon-chai": {
@@ -1118,8 +1118,8 @@
       "integrity": "sha512-bKQqIpew7mmIGNRlxW6Zli/QVyc3zikpGzCa797B/tRnD9OtHvZ/ts8sYXV+Ilj9u3QRaUEM8xrjgd1gwm1BpQ==",
       "dev": true,
       "requires": {
-        "@types/chai": "4.2.21",
-        "@types/sinon": "10.0.2"
+        "@types/chai": "*",
+        "@types/sinon": "*"
       }
     },
     "@types/underscore": {
@@ -1134,8 +1134,8 @@
       "integrity": "sha512-fhZ9DyvDYDwHZUp5/STa9XW2re0E8GxoioYJ4pEUZ13YHpApSagixj7IAdoYH5uAK+UalGq6Ml8LYzmgRA/q+A==",
       "dev": true,
       "requires": {
-        "@types/bn.js": "5.1.0",
-        "@types/underscore": "1.11.3"
+        "@types/bn.js": "*",
+        "@types/underscore": "*"
       }
     },
     "@yarnpkg/lockfile": {
@@ -1150,7 +1150,7 @@
       "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
       "dev": true,
       "requires": {
-        "event-target-shim": "5.0.1"
+        "event-target-shim": "^5.0.0"
       }
     },
     "abstract-leveldown": {
@@ -1159,11 +1159,11 @@
       "integrity": "sha512-TU5nlYgta8YrBMNpc9FwQzRbiXsj49gsALsXadbGHt9CROPzX5fB0rWDR5mtdpOOKa5XqRFpbj1QroPAoPzVjQ==",
       "dev": true,
       "requires": {
-        "buffer": "5.7.1",
-        "immediate": "3.3.0",
-        "level-concat-iterator": "2.0.1",
-        "level-supports": "1.0.1",
-        "xtend": "4.0.2"
+        "buffer": "^5.5.0",
+        "immediate": "^3.2.3",
+        "level-concat-iterator": "~2.0.0",
+        "level-supports": "~1.0.0",
+        "xtend": "~4.0.0"
       }
     },
     "acorn": {
@@ -1196,7 +1196,7 @@
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
       "dev": true,
       "requires": {
-        "debug": "4.3.2"
+        "debug": "4"
       }
     },
     "ajv": {
@@ -1205,10 +1205,10 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "requires": {
-        "fast-deep-equal": "3.1.3",
-        "fast-json-stable-stringify": "2.1.0",
-        "json-schema-traverse": "0.4.1",
-        "uri-js": "4.4.1"
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
       }
     },
     "ansi-colors": {
@@ -1223,7 +1223,7 @@
       "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
       "dev": true,
       "requires": {
-        "type-fest": "0.21.3"
+        "type-fest": "^0.21.3"
       }
     },
     "ansi-regex": {
@@ -1238,7 +1238,7 @@
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "dev": true,
       "requires": {
-        "color-convert": "1.9.3"
+        "color-convert": "^1.9.0"
       }
     },
     "anymatch": {
@@ -1247,8 +1247,8 @@
       "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
       "dev": true,
       "requires": {
-        "normalize-path": "3.0.0",
-        "picomatch": "2.3.0"
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
       }
     },
     "arg": {
@@ -1263,7 +1263,7 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "array-back": {
@@ -1272,7 +1272,7 @@
       "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
       "dev": true,
       "requires": {
-        "typical": "2.6.1"
+        "typical": "^2.6.1"
       }
     },
     "asap": {
@@ -1287,7 +1287,7 @@
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
       "dev": true,
       "requires": {
-        "safer-buffer": "2.1.2"
+        "safer-buffer": "~2.1.0"
       }
     },
     "assert-plus": {
@@ -1308,7 +1308,7 @@
       "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
       "dev": true,
       "requires": {
-        "lodash": "4.17.21"
+        "lodash": "^4.17.14"
       }
     },
     "async-eventemitter": {
@@ -1317,7 +1317,7 @@
       "integrity": "sha512-pd20BwL7Yt1zwDFy+8MX8F1+WCT8aQeKj0kQnTrH9WaeRETlRamVhD0JtRPmrV4GfOJ2F9CvdQkZeZhnh2TuHw==",
       "dev": true,
       "requires": {
-        "async": "2.6.3"
+        "async": "^2.4.0"
       }
     },
     "asynckit": {
@@ -1344,7 +1344,7 @@
       "integrity": "sha512-JtoZ3Ndke/+Iwt5n+BgSli/3idTvpt5OjKyoCmz4LX5+lPiY5l7C1colYezhlxThjNa/NhngCUWZSZFypIFuaA==",
       "dev": true,
       "requires": {
-        "follow-redirects": "1.14.3"
+        "follow-redirects": "^1.14.0"
       }
     },
     "balanced-match": {
@@ -1359,7 +1359,7 @@
       "integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.2.1"
+        "safe-buffer": "^5.0.1"
       }
     },
     "base64-js": {
@@ -1374,7 +1374,7 @@
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "dev": true,
       "requires": {
-        "tweetnacl": "0.14.5"
+        "tweetnacl": "^0.14.3"
       }
     },
     "bech32": {
@@ -1410,7 +1410,7 @@
       "integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.2.1"
+        "safe-buffer": "^5.0.1"
       }
     },
     "blakejs": {
@@ -1437,7 +1437,7 @@
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.2",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -1447,7 +1447,7 @@
       "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
       "dev": true,
       "requires": {
-        "fill-range": "7.0.1"
+        "fill-range": "^7.0.1"
       }
     },
     "brorand": {
@@ -1468,12 +1468,12 @@
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dev": true,
       "requires": {
-        "buffer-xor": "1.0.3",
-        "cipher-base": "1.0.4",
-        "create-hash": "1.2.0",
-        "evp_bytestokey": "1.0.3",
-        "inherits": "2.0.4",
-        "safe-buffer": "5.2.1"
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "bs58": {
@@ -1482,7 +1482,7 @@
       "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
       "dev": true,
       "requires": {
-        "base-x": "3.0.8"
+        "base-x": "^3.0.2"
       }
     },
     "bs58check": {
@@ -1491,9 +1491,9 @@
       "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
       "dev": true,
       "requires": {
-        "bs58": "4.0.1",
-        "create-hash": "1.2.0",
-        "safe-buffer": "5.2.1"
+        "bs58": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "safe-buffer": "^5.1.2"
       }
     },
     "buffer": {
@@ -1502,8 +1502,8 @@
       "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
       "dev": true,
       "requires": {
-        "base64-js": "1.5.1",
-        "ieee754": "1.2.1"
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "buffer-from": {
@@ -1536,8 +1536,8 @@
       "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
       "dev": true,
       "requires": {
-        "function-bind": "1.1.1",
-        "get-intrinsic": "1.1.1"
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
       }
     },
     "camelcase": {
@@ -1558,8 +1558,8 @@
       "integrity": "sha512-5IMhi9e1QU76ppa5/ajP1BmMWZ2FHkhAhjeVKQ/EFCgYSEaeVaoGtL7cxJskf9oCCk+XjzaIdc3IuU/dbA/o2A==",
       "dev": true,
       "requires": {
-        "bignumber.js": "9.0.1",
-        "nofilter": "1.0.4"
+        "bignumber.js": "^9.0.1",
+        "nofilter": "^1.0.4"
       }
     },
     "chai": {
@@ -1568,12 +1568,12 @@
       "integrity": "sha512-yS5H68VYOCtN1cjfwumDSuzn/9c+yza4f3reKXlE5rUg7SFcCEy90gJvydNgOYtblyf4Zi6jIWRnXOgErta0KA==",
       "dev": true,
       "requires": {
-        "assertion-error": "1.1.0",
-        "check-error": "1.0.2",
-        "deep-eql": "3.0.1",
-        "get-func-name": "2.0.0",
-        "pathval": "1.1.1",
-        "type-detect": "4.0.8"
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.0.5"
       }
     },
     "chalk": {
@@ -1582,9 +1582,9 @@
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "dev": true,
       "requires": {
-        "ansi-styles": "3.2.1",
-        "escape-string-regexp": "1.0.5",
-        "supports-color": "5.5.0"
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
       }
     },
     "charenc": {
@@ -1605,14 +1605,14 @@
       "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
       "dev": true,
       "requires": {
-        "anymatch": "3.1.2",
-        "braces": "3.0.2",
-        "fsevents": "2.3.2",
-        "glob-parent": "5.1.2",
-        "is-binary-path": "2.1.0",
-        "is-glob": "4.0.1",
-        "normalize-path": "3.0.0",
-        "readdirp": "3.6.0"
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "fsevents": "~2.3.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
       }
     },
     "ci-info": {
@@ -1627,8 +1627,8 @@
       "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.4",
-        "safe-buffer": "5.2.1"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "cli-table3": {
@@ -1637,9 +1637,9 @@
       "integrity": "sha512-7Qg2Jrep1S/+Q3EceiZtQcDPWxhAvBw+ERf1162v4sikJrvojMHFqXt8QIVha8UlH9rgU0BeWPytZ9/TzYqlUw==",
       "dev": true,
       "requires": {
-        "colors": "1.4.0",
-        "object-assign": "4.1.1",
-        "string-width": "2.1.1"
+        "colors": "^1.1.2",
+        "object-assign": "^4.1.0",
+        "string-width": "^2.1.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -1660,8 +1660,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           }
         },
         "strip-ansi": {
@@ -1670,7 +1670,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -1681,9 +1681,9 @@
       "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
       "dev": true,
       "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "wrap-ansi": "2.1.0"
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wrap-ansi": "^2.0.0"
       }
     },
     "code-point-at": {
@@ -1719,7 +1719,7 @@
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "dev": true,
       "requires": {
-        "delayed-stream": "1.0.0"
+        "delayed-stream": "~1.0.0"
       }
     },
     "command-exists": {
@@ -1734,9 +1734,9 @@
       "integrity": "sha512-aUdPvQRAyBvQd2n7jXcsMDz68ckBJELXNzBybCHOibUWEg0mWTnaYCSRU8h9R+aNRSvDihJtssSRCiDRpLaezA==",
       "dev": true,
       "requires": {
-        "array-back": "2.0.0",
-        "find-replace": "1.0.3",
-        "typical": "2.6.1"
+        "array-back": "^2.0.0",
+        "find-replace": "^1.0.3",
+        "typical": "^2.6.1"
       }
     },
     "commander": {
@@ -1757,10 +1757,10 @@
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "dev": true,
       "requires": {
-        "buffer-from": "1.1.2",
-        "inherits": "2.0.4",
-        "readable-stream": "2.3.7",
-        "typedarray": "0.0.6"
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
       },
       "dependencies": {
         "readable-stream": {
@@ -1769,13 +1769,13 @@
           "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.4",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.1",
-            "safe-buffer": "5.1.2",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "safe-buffer": {
@@ -1790,7 +1790,7 @@
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.2"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -1819,8 +1819,8 @@
       "integrity": "sha512-1uBwHxF+Y/4yF5G48fwnKq6QsIXheor3ZLPT80yGBV1oEUwpPojlEhQbWKVw1VwcTQyMGHK1/XMmTjmlsmTTGA==",
       "dev": true,
       "requires": {
-        "exit-on-epipe": "1.0.1",
-        "printj": "1.1.2"
+        "exit-on-epipe": "~1.0.1",
+        "printj": "~1.1.0"
       }
     },
     "create-hash": {
@@ -1829,11 +1829,11 @@
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "dev": true,
       "requires": {
-        "cipher-base": "1.0.4",
-        "inherits": "2.0.4",
-        "md5.js": "1.3.5",
-        "ripemd160": "2.0.2",
-        "sha.js": "2.4.11"
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "md5.js": "^1.3.4",
+        "ripemd160": "^2.0.1",
+        "sha.js": "^2.4.0"
       }
     },
     "create-hmac": {
@@ -1842,12 +1842,12 @@
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "dev": true,
       "requires": {
-        "cipher-base": "1.0.4",
-        "create-hash": "1.2.0",
-        "inherits": "2.0.4",
-        "ripemd160": "2.0.2",
-        "safe-buffer": "5.2.1",
-        "sha.js": "2.4.11"
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
       }
     },
     "create-require": {
@@ -1862,11 +1862,11 @@
       "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
       "dev": true,
       "requires": {
-        "nice-try": "1.0.5",
-        "path-key": "2.0.1",
-        "semver": "5.7.1",
-        "shebang-command": "1.2.0",
-        "which": "1.3.1"
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
       },
       "dependencies": {
         "semver": {
@@ -1889,7 +1889,7 @@
       "integrity": "sha512-s6OYSXAK3IdKqYO33y09jhypG/bSDHPuyCme/IdEHfWpLf/jKcpitVFyOC6UemgGk8v7Q5u2XE0vvwmanxhGlQ==",
       "dev": true,
       "requires": {
-        "minimist": "1.2.5"
+        "minimist": "^1.2.0"
       }
     },
     "dashdash": {
@@ -1898,7 +1898,7 @@
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "debug": {
@@ -1928,7 +1928,7 @@
       "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
       "dev": true,
       "requires": {
-        "mimic-response": "1.0.1"
+        "mimic-response": "^1.0.0"
       }
     },
     "deep-eql": {
@@ -1937,7 +1937,7 @@
       "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
       "dev": true,
       "requires": {
-        "type-detect": "4.0.8"
+        "type-detect": "^4.0.0"
       }
     },
     "deferred-leveldown": {
@@ -1946,8 +1946,8 @@
       "integrity": "sha512-a59VOT+oDy7vtAbLRCZwWgxu2BaCfd5Hk7wxJd48ei7I+nsg8Orlb9CLG0PMZienk9BSUKgeAqkO2+Lw+1+Ukw==",
       "dev": true,
       "requires": {
-        "abstract-leveldown": "6.2.3",
-        "inherits": "2.0.4"
+        "abstract-leveldown": "~6.2.1",
+        "inherits": "^2.0.3"
       },
       "dependencies": {
         "abstract-leveldown": {
@@ -1956,11 +1956,11 @@
           "integrity": "sha512-BsLm5vFMRUrrLeCcRc+G0t2qOaTzpoJQLOubq2XM72eNpjF5UdU5o/5NvlNhx95XHcAvcl8OMXr4mlg/fRgUXQ==",
           "dev": true,
           "requires": {
-            "buffer": "5.7.1",
-            "immediate": "3.3.0",
-            "level-concat-iterator": "2.0.1",
-            "level-supports": "1.0.1",
-            "xtend": "4.0.2"
+            "buffer": "^5.5.0",
+            "immediate": "^3.2.3",
+            "level-concat-iterator": "~2.0.0",
+            "level-supports": "~1.0.0",
+            "xtend": "~4.0.0"
           }
         }
       }
@@ -1971,7 +1971,7 @@
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
       "dev": true,
       "requires": {
-        "object-keys": "1.1.1"
+        "object-keys": "^1.0.12"
       }
     },
     "delayed-stream": {
@@ -2010,9 +2010,9 @@
       "integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
       "dev": true,
       "requires": {
-        "browserify-aes": "1.2.0",
-        "create-hash": "1.2.0",
-        "create-hmac": "1.1.7"
+        "browserify-aes": "^1.0.6",
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4"
       }
     },
     "ecc-jsbn": {
@@ -2021,8 +2021,8 @@
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "dev": true,
       "requires": {
-        "jsbn": "0.1.1",
-        "safer-buffer": "2.1.2"
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
       }
     },
     "elliptic": {
@@ -2031,13 +2031,13 @@
       "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
       "dev": true,
       "requires": {
-        "bn.js": "4.12.0",
-        "brorand": "1.1.0",
-        "hash.js": "1.1.7",
-        "hmac-drbg": "1.0.1",
-        "inherits": "2.0.4",
-        "minimalistic-assert": "1.0.1",
-        "minimalistic-crypto-utils": "1.0.1"
+        "bn.js": "^4.11.9",
+        "brorand": "^1.1.0",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.1",
+        "inherits": "^2.0.4",
+        "minimalistic-assert": "^1.0.1",
+        "minimalistic-crypto-utils": "^1.0.1"
       }
     },
     "emoji-regex": {
@@ -2052,10 +2052,10 @@
       "integrity": "sha512-QKrV0iKR6MZVJV08QY0wp1e7vF6QbhnbQhb07bwpEyuz4uZiZgPlEGdkCROuFkUwdxlFaiPIhjyarH1ee/3vhw==",
       "dev": true,
       "requires": {
-        "abstract-leveldown": "6.3.0",
-        "inherits": "2.0.4",
-        "level-codec": "9.0.2",
-        "level-errors": "2.0.1"
+        "abstract-leveldown": "^6.2.1",
+        "inherits": "^2.0.3",
+        "level-codec": "^9.0.0",
+        "level-errors": "^2.0.0"
       }
     },
     "enquirer": {
@@ -2064,7 +2064,7 @@
       "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
       "dev": true,
       "requires": {
-        "ansi-colors": "4.1.1"
+        "ansi-colors": "^4.1.1"
       }
     },
     "env-paths": {
@@ -2079,7 +2079,7 @@
       "integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
       "dev": true,
       "requires": {
-        "prr": "1.0.1"
+        "prr": "~1.0.1"
       }
     },
     "error-ex": {
@@ -2088,7 +2088,7 @@
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "dev": true,
       "requires": {
-        "is-arrayish": "0.2.1"
+        "is-arrayish": "^0.2.1"
       }
     },
     "es-abstract": {
@@ -2097,23 +2097,23 @@
       "integrity": "sha512-DDggyJLoS91CkJjgauM5c0yZMjiD1uK3KcaCeAmffGwZ+ODWzOkPN4QwRbsK5DOFf06fywmyLci3ZD8jLGhVYA==",
       "dev": true,
       "requires": {
-        "call-bind": "1.0.2",
-        "es-to-primitive": "1.2.1",
-        "function-bind": "1.1.1",
-        "get-intrinsic": "1.1.1",
-        "has": "1.0.3",
-        "has-symbols": "1.0.2",
-        "internal-slot": "1.0.3",
-        "is-callable": "1.2.4",
-        "is-negative-zero": "2.0.1",
-        "is-regex": "1.1.4",
-        "is-string": "1.0.7",
-        "object-inspect": "1.11.0",
-        "object-keys": "1.1.1",
-        "object.assign": "4.1.2",
-        "string.prototype.trimend": "1.0.4",
-        "string.prototype.trimstart": "1.0.4",
-        "unbox-primitive": "1.0.1"
+        "call-bind": "^1.0.2",
+        "es-to-primitive": "^1.2.1",
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.2",
+        "internal-slot": "^1.0.3",
+        "is-callable": "^1.2.3",
+        "is-negative-zero": "^2.0.1",
+        "is-regex": "^1.1.3",
+        "is-string": "^1.0.6",
+        "object-inspect": "^1.11.0",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.2",
+        "string.prototype.trimend": "^1.0.4",
+        "string.prototype.trimstart": "^1.0.4",
+        "unbox-primitive": "^1.0.1"
       }
     },
     "es-to-primitive": {
@@ -2122,9 +2122,9 @@
       "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
       "dev": true,
       "requires": {
-        "is-callable": "1.2.4",
-        "is-date-object": "1.0.5",
-        "is-symbol": "1.0.4"
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
       }
     },
     "escape-string-regexp": {
@@ -2145,8 +2145,8 @@
       "integrity": "sha1-IprEbsqG1S4MmR58sq74P/D2i88=",
       "dev": true,
       "requires": {
-        "idna-uts46-hx": "2.3.1",
-        "js-sha3": "0.5.7"
+        "idna-uts46-hx": "^2.3.1",
+        "js-sha3": "^0.5.7"
       }
     },
     "eth-gas-reporter": {
@@ -2155,21 +2155,21 @@
       "integrity": "sha512-L1FlC792aTf3j/j+gGzSNlGrXKSxNPXQNk6TnV5NNZ2w3jnQCRyJjDl0zUo25Cq2t90IS5vGdbkwqFQK7Ce+kw==",
       "dev": true,
       "requires": {
-        "@ethersproject/abi": "5.4.1",
-        "@solidity-parser/parser": "0.12.2",
-        "cli-table3": "0.5.1",
-        "colors": "1.4.0",
+        "@ethersproject/abi": "^5.0.0-beta.146",
+        "@solidity-parser/parser": "^0.12.0",
+        "cli-table3": "^0.5.0",
+        "colors": "^1.1.2",
         "ethereumjs-util": "6.2.0",
-        "ethers": "4.0.49",
-        "fs-readdir-recursive": "1.1.0",
-        "lodash": "4.17.21",
-        "markdown-table": "1.1.3",
-        "mocha": "7.2.0",
-        "req-cwd": "2.0.0",
-        "request": "2.88.2",
-        "request-promise-native": "1.0.9",
-        "sha1": "1.1.1",
-        "sync-request": "6.1.0"
+        "ethers": "^4.0.40",
+        "fs-readdir-recursive": "^1.1.0",
+        "lodash": "^4.17.14",
+        "markdown-table": "^1.1.3",
+        "mocha": "^7.1.1",
+        "req-cwd": "^2.0.0",
+        "request": "^2.88.0",
+        "request-promise-native": "^1.0.5",
+        "sha1": "^1.1.1",
+        "sync-request": "^6.0.0"
       },
       "dependencies": {
         "@solidity-parser/parser": {
@@ -2184,7 +2184,7 @@
           "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
           "dev": true,
           "requires": {
-            "@types/node": "15.14.9"
+            "@types/node": "*"
           }
         },
         "ethereumjs-util": {
@@ -2193,13 +2193,13 @@
           "integrity": "sha512-vb0XN9J2QGdZGIEKG2vXM+kUdEivUfU6Wmi5y0cg+LRhDYKnXIZ/Lz7XjFbHRR9VIKq2lVGLzGBkA++y2nOdOQ==",
           "dev": true,
           "requires": {
-            "@types/bn.js": "4.11.6",
-            "bn.js": "4.12.0",
-            "create-hash": "1.2.0",
+            "@types/bn.js": "^4.11.3",
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
             "ethjs-util": "0.1.6",
-            "keccak": "2.1.0",
-            "rlp": "2.2.6",
-            "secp256k1": "3.8.0"
+            "keccak": "^2.0.0",
+            "rlp": "^2.2.3",
+            "secp256k1": "^3.0.1"
           }
         },
         "ethers": {
@@ -2209,7 +2209,7 @@
           "dev": true,
           "requires": {
             "aes-js": "3.0.0",
-            "bn.js": "4.12.0",
+            "bn.js": "^4.11.9",
             "elliptic": "6.5.4",
             "hash.js": "1.1.3",
             "js-sha3": "0.5.7",
@@ -2225,8 +2225,8 @@
           "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
           "dev": true,
           "requires": {
-            "inherits": "2.0.4",
-            "minimalistic-assert": "1.0.1"
+            "inherits": "^2.0.3",
+            "minimalistic-assert": "^1.0.0"
           }
         },
         "keccak": {
@@ -2235,10 +2235,10 @@
           "integrity": "sha512-m1wbJRTo+gWbctZWay9i26v5fFnYkOn7D5PCxJ3fZUGUEb49dE1Pm4BREUYCt/aoO6di7jeoGmhvqN9Nzylm3Q==",
           "dev": true,
           "requires": {
-            "bindings": "1.5.0",
-            "inherits": "2.0.4",
-            "nan": "2.15.0",
-            "safe-buffer": "5.2.1"
+            "bindings": "^1.5.0",
+            "inherits": "^2.0.4",
+            "nan": "^2.14.0",
+            "safe-buffer": "^5.2.0"
           }
         },
         "scrypt-js": {
@@ -2253,14 +2253,14 @@
           "integrity": "sha512-k5ke5avRZbtl9Tqx/SA7CbY3NF6Ro+Sj9cZxezFzuBlLDmyqPiL8hJJ+EmzD8Ig4LUDByHJ3/iPOVoRixs/hmw==",
           "dev": true,
           "requires": {
-            "bindings": "1.5.0",
-            "bip66": "1.1.5",
-            "bn.js": "4.12.0",
-            "create-hash": "1.2.0",
-            "drbg.js": "1.0.1",
-            "elliptic": "6.5.4",
-            "nan": "2.15.0",
-            "safe-buffer": "5.2.1"
+            "bindings": "^1.5.0",
+            "bip66": "^1.1.5",
+            "bn.js": "^4.11.8",
+            "create-hash": "^1.2.0",
+            "drbg.js": "^1.0.1",
+            "elliptic": "^6.5.2",
+            "nan": "^2.14.0",
+            "safe-buffer": "^5.1.2"
           }
         },
         "setimmediate": {
@@ -2283,9 +2283,9 @@
       "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
       "dev": true,
       "requires": {
-        "bn.js": "4.12.0",
-        "elliptic": "6.5.4",
-        "xhr-request-promise": "0.1.3"
+        "bn.js": "^4.11.6",
+        "elliptic": "^6.4.0",
+        "xhr-request-promise": "^0.1.2"
       }
     },
     "eth-sig-util": {
@@ -2295,9 +2295,9 @@
       "dev": true,
       "requires": {
         "ethereumjs-abi": "0.6.8",
-        "ethereumjs-util": "5.2.1",
-        "tweetnacl": "1.0.3",
-        "tweetnacl-util": "0.15.1"
+        "ethereumjs-util": "^5.1.1",
+        "tweetnacl": "^1.0.3",
+        "tweetnacl-util": "^0.15.0"
       },
       "dependencies": {
         "ethereumjs-util": {
@@ -2306,13 +2306,13 @@
           "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
           "dev": true,
           "requires": {
-            "bn.js": "4.12.0",
-            "create-hash": "1.2.0",
-            "elliptic": "6.5.4",
-            "ethereum-cryptography": "0.1.3",
-            "ethjs-util": "0.1.6",
-            "rlp": "2.2.6",
-            "safe-buffer": "5.2.1"
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "elliptic": "^6.5.2",
+            "ethereum-cryptography": "^0.1.3",
+            "ethjs-util": "^0.1.3",
+            "rlp": "^2.0.0",
+            "safe-buffer": "^5.1.1"
           }
         },
         "tweetnacl": {
@@ -2329,7 +2329,7 @@
       "integrity": "sha512-rxJ5OFN3RwjQxDcFP2Z5+Q9ho4eIdEmSc2ht0fCu8Se9nbXjZ7/031uXoUYJ87KHCOdVeiUuwSnoS7hmYAGVHA==",
       "dev": true,
       "requires": {
-        "js-sha3": "0.8.0"
+        "js-sha3": "^0.8.0"
       },
       "dependencies": {
         "js-sha3": {
@@ -2346,21 +2346,21 @@
       "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
       "dev": true,
       "requires": {
-        "@types/pbkdf2": "3.1.0",
-        "@types/secp256k1": "4.0.3",
-        "blakejs": "1.1.1",
-        "browserify-aes": "1.2.0",
-        "bs58check": "2.1.2",
-        "create-hash": "1.2.0",
-        "create-hmac": "1.1.7",
-        "hash.js": "1.1.7",
-        "keccak": "3.0.2",
-        "pbkdf2": "3.1.2",
-        "randombytes": "2.1.0",
-        "safe-buffer": "5.2.1",
-        "scrypt-js": "3.0.1",
-        "secp256k1": "4.0.2",
-        "setimmediate": "1.0.5"
+        "@types/pbkdf2": "^3.0.0",
+        "@types/secp256k1": "^4.0.1",
+        "blakejs": "^1.1.0",
+        "browserify-aes": "^1.2.0",
+        "bs58check": "^2.1.2",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "hash.js": "^1.1.7",
+        "keccak": "^3.0.0",
+        "pbkdf2": "^3.0.17",
+        "randombytes": "^2.1.0",
+        "safe-buffer": "^5.1.2",
+        "scrypt-js": "^3.0.0",
+        "secp256k1": "^4.0.1",
+        "setimmediate": "^1.0.5"
       }
     },
     "ethereum-waffle": {
@@ -2369,11 +2369,11 @@
       "integrity": "sha512-ADBqZCkoSA5Isk486ntKJVjFEawIiC+3HxNqpJqONvh3YXBTNiRfXvJtGuAFLXPG91QaqkGqILEHANAo7j/olQ==",
       "dev": true,
       "requires": {
-        "@ethereum-waffle/chai": "3.4.0",
-        "@ethereum-waffle/compiler": "3.4.0",
-        "@ethereum-waffle/mock-contract": "3.3.0",
-        "@ethereum-waffle/provider": "3.4.0",
-        "ethers": "5.4.6"
+        "@ethereum-waffle/chai": "^3.4.0",
+        "@ethereum-waffle/compiler": "^3.4.0",
+        "@ethereum-waffle/mock-contract": "^3.3.0",
+        "@ethereum-waffle/provider": "^3.4.0",
+        "ethers": "^5.0.1"
       }
     },
     "ethereumjs-abi": {
@@ -2382,8 +2382,8 @@
       "integrity": "sha512-Tx0r/iXI6r+lRsdvkFDlut0N08jWMnKRZ6Gkq+Nmw75lZe4e6o3EkSnkaBP5NF6+m5PTGAr9JP43N3LyeoglsA==",
       "dev": true,
       "requires": {
-        "bn.js": "4.12.0",
-        "ethereumjs-util": "6.2.1"
+        "bn.js": "^4.11.8",
+        "ethereumjs-util": "^6.0.0"
       },
       "dependencies": {
         "@types/bn.js": {
@@ -2392,7 +2392,7 @@
           "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
           "dev": true,
           "requires": {
-            "@types/node": "15.14.9"
+            "@types/node": "*"
           }
         },
         "ethereumjs-util": {
@@ -2401,13 +2401,13 @@
           "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
           "dev": true,
           "requires": {
-            "@types/bn.js": "4.11.6",
-            "bn.js": "4.12.0",
-            "create-hash": "1.2.0",
-            "elliptic": "6.5.4",
-            "ethereum-cryptography": "0.1.3",
+            "@types/bn.js": "^4.11.3",
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "elliptic": "^6.5.2",
+            "ethereum-cryptography": "^0.1.3",
             "ethjs-util": "0.1.6",
-            "rlp": "2.2.6"
+            "rlp": "^2.2.3"
           }
         }
       }
@@ -2418,12 +2418,12 @@
       "integrity": "sha512-kR+vhu++mUDARrsMMhsjjzPduRVAeundLGXucGRHF3B4oEltOUspfgCVco4kckucj3FMlLaZHUl9n7/kdmr6Tw==",
       "dev": true,
       "requires": {
-        "@types/bn.js": "5.1.0",
-        "bn.js": "5.2.0",
-        "create-hash": "1.2.0",
-        "ethereum-cryptography": "0.1.3",
+        "@types/bn.js": "^5.1.0",
+        "bn.js": "^5.1.2",
+        "create-hash": "^1.1.2",
+        "ethereum-cryptography": "^0.1.3",
         "ethjs-util": "0.1.6",
-        "rlp": "2.2.6"
+        "rlp": "^2.2.4"
       },
       "dependencies": {
         "bn.js": {
@@ -2512,8 +2512,8 @@
       "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
       "dev": true,
       "requires": {
-        "md5.js": "1.3.5",
-        "safe-buffer": "5.2.1"
+        "md5.js": "^1.3.4",
+        "safe-buffer": "^5.1.1"
       }
     },
     "exit-on-epipe": {
@@ -2558,7 +2558,7 @@
       "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
       "dev": true,
       "requires": {
-        "to-regex-range": "5.0.1"
+        "to-regex-range": "^5.0.1"
       }
     },
     "find-replace": {
@@ -2567,8 +2567,8 @@
       "integrity": "sha1-uI5zZNLZyVlVnziMZmcNYTBEH6A=",
       "dev": true,
       "requires": {
-        "array-back": "1.0.4",
-        "test-value": "2.1.0"
+        "array-back": "^1.0.4",
+        "test-value": "^2.1.0"
       },
       "dependencies": {
         "array-back": {
@@ -2577,7 +2577,7 @@
           "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
           "dev": true,
           "requires": {
-            "typical": "2.6.1"
+            "typical": "^2.6.0"
           }
         }
       }
@@ -2588,8 +2588,8 @@
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
       "dev": true,
       "requires": {
-        "path-exists": "2.1.0",
-        "pinkie-promise": "2.0.1"
+        "path-exists": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "find-yarn-workspace-root": {
@@ -2598,7 +2598,7 @@
       "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
       "dev": true,
       "requires": {
-        "micromatch": "4.0.4"
+        "micromatch": "^4.0.2"
       }
     },
     "flat": {
@@ -2607,7 +2607,7 @@
       "integrity": "sha512-FmTtBsHskrU6FJ2VxCnsDb84wu9zhmO3cUX2kGFb5tuwhfXxGciiT0oRY+cck35QmG+NmGh5eLz6lLCpWTqwpA==",
       "dev": true,
       "requires": {
-        "is-buffer": "2.0.5"
+        "is-buffer": "~2.0.3"
       }
     },
     "follow-redirects": {
@@ -2622,7 +2622,7 @@
       "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
       "dev": true,
       "requires": {
-        "is-callable": "1.2.4"
+        "is-callable": "^1.1.3"
       }
     },
     "forever-agent": {
@@ -2637,9 +2637,9 @@
       "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
       "dev": true,
       "requires": {
-        "asynckit": "0.4.0",
-        "combined-stream": "1.0.8",
-        "mime-types": "2.1.32"
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
       }
     },
     "fp-ts": {
@@ -2654,9 +2654,9 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.2.8",
-        "jsonfile": "4.0.0",
-        "universalify": "0.1.2"
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
       }
     },
     "fs-readdir-recursive": {
@@ -2733,16 +2733,17 @@
           "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.0-beta.153.tgz",
           "integrity": "sha512-aXweZ1Z7vMNzJdLpR1CZUAIgnwjrZeUSvN9syCwlBaEBUFJmFY+HHnfuTI5vIhVs/mRkfJVrbEyl51JZQqyjAg==",
           "dev": true,
+          "optional": true,
           "requires": {
-            "@ethersproject/address": "5.0.9",
-            "@ethersproject/bignumber": "5.0.13",
-            "@ethersproject/bytes": "5.0.9",
-            "@ethersproject/constants": "5.0.8",
-            "@ethersproject/hash": "5.0.10",
-            "@ethersproject/keccak256": "5.0.7",
-            "@ethersproject/logger": "5.0.8",
-            "@ethersproject/properties": "5.0.7",
-            "@ethersproject/strings": "5.0.8"
+            "@ethersproject/address": ">=5.0.0-beta.128",
+            "@ethersproject/bignumber": ">=5.0.0-beta.130",
+            "@ethersproject/bytes": ">=5.0.0-beta.129",
+            "@ethersproject/constants": ">=5.0.0-beta.128",
+            "@ethersproject/hash": ">=5.0.0-beta.128",
+            "@ethersproject/keccak256": ">=5.0.0-beta.127",
+            "@ethersproject/logger": ">=5.0.0-beta.129",
+            "@ethersproject/properties": ">=5.0.0-beta.131",
+            "@ethersproject/strings": ">=5.0.0-beta.130"
           }
         },
         "@ethersproject/abstract-provider": {
@@ -2750,14 +2751,15 @@
           "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.0.8.tgz",
           "integrity": "sha512-fqJXkewcGdi8LogKMgRyzc/Ls2js07yor7+g9KfPs09uPOcQLg7cc34JN+lk34HH9gg2HU0DIA5797ZR8znkfw==",
           "dev": true,
+          "optional": true,
           "requires": {
-            "@ethersproject/bignumber": "5.0.13",
-            "@ethersproject/bytes": "5.0.9",
-            "@ethersproject/logger": "5.0.8",
-            "@ethersproject/networks": "5.0.7",
-            "@ethersproject/properties": "5.0.7",
-            "@ethersproject/transactions": "5.0.9",
-            "@ethersproject/web": "5.0.12"
+            "@ethersproject/bignumber": "^5.0.13",
+            "@ethersproject/bytes": "^5.0.9",
+            "@ethersproject/logger": "^5.0.8",
+            "@ethersproject/networks": "^5.0.7",
+            "@ethersproject/properties": "^5.0.7",
+            "@ethersproject/transactions": "^5.0.9",
+            "@ethersproject/web": "^5.0.12"
           }
         },
         "@ethersproject/abstract-signer": {
@@ -2765,12 +2767,13 @@
           "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.0.10.tgz",
           "integrity": "sha512-irx7kH7FDAeW7QChDPW19WsxqeB1d3XLyOLSXm0bfPqL1SS07LXWltBJUBUxqC03ORpAOcM3JQj57DU8JnVY2g==",
           "dev": true,
+          "optional": true,
           "requires": {
-            "@ethersproject/abstract-provider": "5.0.8",
-            "@ethersproject/bignumber": "5.0.13",
-            "@ethersproject/bytes": "5.0.9",
-            "@ethersproject/logger": "5.0.8",
-            "@ethersproject/properties": "5.0.7"
+            "@ethersproject/abstract-provider": "^5.0.8",
+            "@ethersproject/bignumber": "^5.0.13",
+            "@ethersproject/bytes": "^5.0.9",
+            "@ethersproject/logger": "^5.0.8",
+            "@ethersproject/properties": "^5.0.7"
           }
         },
         "@ethersproject/address": {
@@ -2778,12 +2781,13 @@
           "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.9.tgz",
           "integrity": "sha512-gKkmbZDMyGbVjr8nA5P0md1GgESqSGH7ILIrDidPdNXBl4adqbuA3OAuZx/O2oGpL6PtJ9BDa0kHheZ1ToHU3w==",
           "dev": true,
+          "optional": true,
           "requires": {
-            "@ethersproject/bignumber": "5.0.13",
-            "@ethersproject/bytes": "5.0.9",
-            "@ethersproject/keccak256": "5.0.7",
-            "@ethersproject/logger": "5.0.8",
-            "@ethersproject/rlp": "5.0.7"
+            "@ethersproject/bignumber": "^5.0.13",
+            "@ethersproject/bytes": "^5.0.9",
+            "@ethersproject/keccak256": "^5.0.7",
+            "@ethersproject/logger": "^5.0.8",
+            "@ethersproject/rlp": "^5.0.7"
           }
         },
         "@ethersproject/base64": {
@@ -2791,8 +2795,9 @@
           "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.0.7.tgz",
           "integrity": "sha512-S5oh5DVfCo06xwJXT8fQC68mvJfgScTl2AXvbYMsHNfIBTDb084Wx4iA9MNlEReOv6HulkS+gyrUM/j3514rSw==",
           "dev": true,
+          "optional": true,
           "requires": {
-            "@ethersproject/bytes": "5.0.9"
+            "@ethersproject/bytes": "^5.0.9"
           }
         },
         "@ethersproject/bignumber": {
@@ -2800,10 +2805,11 @@
           "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.13.tgz",
           "integrity": "sha512-b89bX5li6aK492yuPP5mPgRVgIxxBP7ksaBtKX5QQBsrZTpNOjf/MR4CjcUrAw8g+RQuD6kap9lPjFgY4U1/5A==",
           "dev": true,
+          "optional": true,
           "requires": {
-            "@ethersproject/bytes": "5.0.9",
-            "@ethersproject/logger": "5.0.8",
-            "bn.js": "4.11.9"
+            "@ethersproject/bytes": "^5.0.9",
+            "@ethersproject/logger": "^5.0.8",
+            "bn.js": "^4.4.0"
           }
         },
         "@ethersproject/bytes": {
@@ -2811,8 +2817,9 @@
           "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.9.tgz",
           "integrity": "sha512-k+17ZViDtAugC0s7HM6rdsTWEdIYII4RPCDkPEuxKc6i40Bs+m6tjRAtCECX06wKZnrEoR9pjOJRXHJ/VLoOcA==",
           "dev": true,
+          "optional": true,
           "requires": {
-            "@ethersproject/logger": "5.0.8"
+            "@ethersproject/logger": "^5.0.8"
           }
         },
         "@ethersproject/constants": {
@@ -2820,8 +2827,9 @@
           "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.8.tgz",
           "integrity": "sha512-sCc73pFBsl59eDfoQR5OCEZCRv5b0iywadunti6MQIr5lt3XpwxK1Iuzd8XSFO02N9jUifvuZRrt0cY0+NBgTg==",
           "dev": true,
+          "optional": true,
           "requires": {
-            "@ethersproject/bignumber": "5.0.13"
+            "@ethersproject/bignumber": "^5.0.13"
           }
         },
         "@ethersproject/hash": {
@@ -2829,15 +2837,16 @@
           "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.0.10.tgz",
           "integrity": "sha512-Tf0bvs6YFhw28LuHnhlDWyr0xfcDxSXdwM4TcskeBbmXVSKLv3bJQEEEBFUcRX0fJuslR3gCVySEaSh7vuMx5w==",
           "dev": true,
+          "optional": true,
           "requires": {
-            "@ethersproject/abstract-signer": "5.0.10",
-            "@ethersproject/address": "5.0.9",
-            "@ethersproject/bignumber": "5.0.13",
-            "@ethersproject/bytes": "5.0.9",
-            "@ethersproject/keccak256": "5.0.7",
-            "@ethersproject/logger": "5.0.8",
-            "@ethersproject/properties": "5.0.7",
-            "@ethersproject/strings": "5.0.8"
+            "@ethersproject/abstract-signer": "^5.0.10",
+            "@ethersproject/address": "^5.0.9",
+            "@ethersproject/bignumber": "^5.0.13",
+            "@ethersproject/bytes": "^5.0.9",
+            "@ethersproject/keccak256": "^5.0.7",
+            "@ethersproject/logger": "^5.0.8",
+            "@ethersproject/properties": "^5.0.7",
+            "@ethersproject/strings": "^5.0.8"
           }
         },
         "@ethersproject/keccak256": {
@@ -2845,8 +2854,9 @@
           "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.7.tgz",
           "integrity": "sha512-zpUBmofWvx9PGfc7IICobgFQSgNmTOGTGLUxSYqZzY/T+b4y/2o5eqf/GGmD7qnTGzKQ42YlLNo+LeDP2qe55g==",
           "dev": true,
+          "optional": true,
           "requires": {
-            "@ethersproject/bytes": "5.0.9",
+            "@ethersproject/bytes": "^5.0.9",
             "js-sha3": "0.5.7"
           }
         },
@@ -2854,15 +2864,17 @@
           "version": "5.0.8",
           "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.8.tgz",
           "integrity": "sha512-SkJCTaVTnaZ3/ieLF5pVftxGEFX56pTH+f2Slrpv7cU0TNpUZNib84QQdukd++sWUp/S7j5t5NW+WegbXd4U/A==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "@ethersproject/networks": {
           "version": "5.0.7",
           "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.0.7.tgz",
           "integrity": "sha512-dI14QATndIcUgcCBL1c5vUr/YsI5cCHLN81rF7PU+yS7Xgp2/Rzbr9+YqpC6NBXHFUASjh6GpKqsVMpufAL0BQ==",
           "dev": true,
+          "optional": true,
           "requires": {
-            "@ethersproject/logger": "5.0.8"
+            "@ethersproject/logger": "^5.0.8"
           }
         },
         "@ethersproject/properties": {
@@ -2870,8 +2882,9 @@
           "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.7.tgz",
           "integrity": "sha512-812H1Rus2vjw0zbasfDI1GLNPDsoyX1pYqiCgaR1BuyKxUTbwcH1B+214l6VGe1v+F6iEVb7WjIwMjKhb4EUsg==",
           "dev": true,
+          "optional": true,
           "requires": {
-            "@ethersproject/logger": "5.0.8"
+            "@ethersproject/logger": "^5.0.8"
           }
         },
         "@ethersproject/rlp": {
@@ -2879,9 +2892,10 @@
           "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.7.tgz",
           "integrity": "sha512-ulUTVEuV7PT4jJTPpfhRHK57tkLEDEY9XSYJtrSNHOqdwMvH0z7BM2AKIMq4LVDlnu4YZASdKrkFGEIO712V9w==",
           "dev": true,
+          "optional": true,
           "requires": {
-            "@ethersproject/bytes": "5.0.9",
-            "@ethersproject/logger": "5.0.8"
+            "@ethersproject/bytes": "^5.0.9",
+            "@ethersproject/logger": "^5.0.8"
           }
         },
         "@ethersproject/signing-key": {
@@ -2889,10 +2903,11 @@
           "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.0.8.tgz",
           "integrity": "sha512-YKxQM45eDa6WAD+s3QZPdm1uW1MutzVuyoepdRRVmMJ8qkk7iOiIhUkZwqKLNxKzEJijt/82ycuOREc9WBNAKg==",
           "dev": true,
+          "optional": true,
           "requires": {
-            "@ethersproject/bytes": "5.0.9",
-            "@ethersproject/logger": "5.0.8",
-            "@ethersproject/properties": "5.0.7",
+            "@ethersproject/bytes": "^5.0.9",
+            "@ethersproject/logger": "^5.0.8",
+            "@ethersproject/properties": "^5.0.7",
             "elliptic": "6.5.3"
           }
         },
@@ -2901,10 +2916,11 @@
           "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.8.tgz",
           "integrity": "sha512-5IsdXf8tMY8QuHl8vTLnk9ehXDDm6x9FB9S9Og5IA1GYhLe5ZewydXSjlJlsqU2t9HRbfv97OJZV/pX8DVA/Hw==",
           "dev": true,
+          "optional": true,
           "requires": {
-            "@ethersproject/bytes": "5.0.9",
-            "@ethersproject/constants": "5.0.8",
-            "@ethersproject/logger": "5.0.8"
+            "@ethersproject/bytes": "^5.0.9",
+            "@ethersproject/constants": "^5.0.8",
+            "@ethersproject/logger": "^5.0.8"
           }
         },
         "@ethersproject/transactions": {
@@ -2912,16 +2928,17 @@
           "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.0.9.tgz",
           "integrity": "sha512-0Fu1yhdFBkrbMjenEr+39tmDxuHmaw0pe9Jb18XuKoItj7Z3p7+UzdHLr2S/okvHDHYPbZE5gtANDdQ3ZL1nBA==",
           "dev": true,
+          "optional": true,
           "requires": {
-            "@ethersproject/address": "5.0.9",
-            "@ethersproject/bignumber": "5.0.13",
-            "@ethersproject/bytes": "5.0.9",
-            "@ethersproject/constants": "5.0.8",
-            "@ethersproject/keccak256": "5.0.7",
-            "@ethersproject/logger": "5.0.8",
-            "@ethersproject/properties": "5.0.7",
-            "@ethersproject/rlp": "5.0.7",
-            "@ethersproject/signing-key": "5.0.8"
+            "@ethersproject/address": "^5.0.9",
+            "@ethersproject/bignumber": "^5.0.13",
+            "@ethersproject/bytes": "^5.0.9",
+            "@ethersproject/constants": "^5.0.8",
+            "@ethersproject/keccak256": "^5.0.7",
+            "@ethersproject/logger": "^5.0.8",
+            "@ethersproject/properties": "^5.0.7",
+            "@ethersproject/rlp": "^5.0.7",
+            "@ethersproject/signing-key": "^5.0.8"
           }
         },
         "@ethersproject/web": {
@@ -2929,12 +2946,13 @@
           "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.0.12.tgz",
           "integrity": "sha512-gVxS5iW0bgidZ76kr7LsTxj4uzN5XpCLzvZrLp8TP+4YgxHfCeetFyQkRPgBEAJdNrexdSBayvyJvzGvOq0O8g==",
           "dev": true,
+          "optional": true,
           "requires": {
-            "@ethersproject/base64": "5.0.7",
-            "@ethersproject/bytes": "5.0.9",
-            "@ethersproject/logger": "5.0.8",
-            "@ethersproject/properties": "5.0.7",
-            "@ethersproject/strings": "5.0.8"
+            "@ethersproject/base64": "^5.0.7",
+            "@ethersproject/bytes": "^5.0.9",
+            "@ethersproject/logger": "^5.0.8",
+            "@ethersproject/properties": "^5.0.7",
+            "@ethersproject/strings": "^5.0.8"
           }
         },
         "@sindresorhus/is": {
@@ -2951,7 +2969,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "defer-to-connect": "1.1.3"
+            "defer-to-connect": "^1.0.1"
           }
         },
         "@types/bn.js": {
@@ -2960,7 +2978,7 @@
           "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
           "dev": true,
           "requires": {
-            "@types/node": "14.14.20"
+            "@types/node": "*"
           }
         },
         "@types/node": {
@@ -2975,7 +2993,7 @@
           "integrity": "sha512-Cf63Rv7jCQ0LaL8tNXmEyqTHuIJxRdlS5vMh1mj5voN4+QFhVZnlZruezqpWYDiJ8UTzhP0VmeLXCmBk66YrMQ==",
           "dev": true,
           "requires": {
-            "@types/node": "14.14.20"
+            "@types/node": "*"
           }
         },
         "@types/secp256k1": {
@@ -2984,7 +3002,7 @@
           "integrity": "sha512-+ZjSA8ELlOp8SlKi0YLB2tz9d5iPNEmOBd+8Rz21wTMdaXQIa9b6TEnD6l5qKOCypE7FSyPyck12qZJxSDNoog==",
           "dev": true,
           "requires": {
-            "@types/node": "14.14.20"
+            "@types/node": "*"
           }
         },
         "@yarnpkg/lockfile": {
@@ -2999,7 +3017,7 @@
           "integrity": "sha512-KUWx9UWGQD12zsmLNj64/pndaz4iJh/Pj7nopgkfDG6RlCcbMZvT6+9l7dchK4idog2Is8VdC/PvNbFuFmalIQ==",
           "dev": true,
           "requires": {
-            "xtend": "4.0.2"
+            "xtend": "~4.0.0"
           }
         },
         "accepts": {
@@ -3009,7 +3027,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "mime-types": "2.1.28",
+            "mime-types": "~2.1.24",
             "negotiator": "0.6.2"
           }
         },
@@ -3026,10 +3044,10 @@
           "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
           "dev": true,
           "requires": {
-            "fast-deep-equal": "3.1.3",
-            "fast-json-stable-stringify": "2.1.0",
-            "json-schema-traverse": "0.4.1",
-            "uri-js": "4.4.1"
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
           }
         },
         "ansi-styles": {
@@ -3038,7 +3056,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.3"
+            "color-convert": "^1.9.0"
           }
         },
         "arr-diff": {
@@ -3078,7 +3096,7 @@
           "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
           "dev": true,
           "requires": {
-            "safer-buffer": "2.1.2"
+            "safer-buffer": "~2.1.0"
           }
         },
         "asn1.js": {
@@ -3086,11 +3104,12 @@
           "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
           "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
           "dev": true,
+          "optional": true,
           "requires": {
-            "bn.js": "4.11.9",
-            "inherits": "2.0.4",
-            "minimalistic-assert": "1.0.1",
-            "safer-buffer": "2.1.2"
+            "bn.js": "^4.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0",
+            "safer-buffer": "^2.1.0"
           }
         },
         "assert-plus": {
@@ -3111,7 +3130,7 @@
           "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
           "dev": true,
           "requires": {
-            "lodash": "4.17.20"
+            "lodash": "^4.17.11"
           }
         },
         "async-eventemitter": {
@@ -3120,7 +3139,7 @@
           "integrity": "sha512-pd20BwL7Yt1zwDFy+8MX8F1+WCT8aQeKj0kQnTrH9WaeRETlRamVhD0JtRPmrV4GfOJ2F9CvdQkZeZhnh2TuHw==",
           "dev": true,
           "requires": {
-            "async": "2.6.2"
+            "async": "^2.4.0"
           }
         },
         "async-limiter": {
@@ -3159,9 +3178,9 @@
           "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "esutils": "2.0.3",
-            "js-tokens": "3.0.2"
+            "chalk": "^1.1.3",
+            "esutils": "^2.0.2",
+            "js-tokens": "^3.0.2"
           },
           "dependencies": {
             "ansi-regex": {
@@ -3182,11 +3201,11 @@
               "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
               "dev": true,
               "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
               }
             },
             "js-tokens": {
@@ -3201,7 +3220,7 @@
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "dev": true,
               "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
               }
             },
             "supports-color": {
@@ -3218,25 +3237,25 @@
           "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
           "dev": true,
           "requires": {
-            "babel-code-frame": "6.26.0",
-            "babel-generator": "6.26.1",
-            "babel-helpers": "6.24.1",
-            "babel-messages": "6.23.0",
-            "babel-register": "6.26.0",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "convert-source-map": "1.7.0",
-            "debug": "2.6.9",
-            "json5": "0.5.1",
-            "lodash": "4.17.20",
-            "minimatch": "3.0.4",
-            "path-is-absolute": "1.0.1",
-            "private": "0.1.8",
-            "slash": "1.0.0",
-            "source-map": "0.5.7"
+            "babel-code-frame": "^6.26.0",
+            "babel-generator": "^6.26.0",
+            "babel-helpers": "^6.24.1",
+            "babel-messages": "^6.23.0",
+            "babel-register": "^6.26.0",
+            "babel-runtime": "^6.26.0",
+            "babel-template": "^6.26.0",
+            "babel-traverse": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "babylon": "^6.18.0",
+            "convert-source-map": "^1.5.1",
+            "debug": "^2.6.9",
+            "json5": "^0.5.1",
+            "lodash": "^4.17.4",
+            "minimatch": "^3.0.4",
+            "path-is-absolute": "^1.0.1",
+            "private": "^0.1.8",
+            "slash": "^1.0.0",
+            "source-map": "^0.5.7"
           },
           "dependencies": {
             "debug": {
@@ -3274,14 +3293,14 @@
           "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
           "dev": true,
           "requires": {
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "detect-indent": "4.0.0",
-            "jsesc": "1.3.0",
-            "lodash": "4.17.20",
-            "source-map": "0.5.7",
-            "trim-right": "1.0.1"
+            "babel-messages": "^6.23.0",
+            "babel-runtime": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "detect-indent": "^4.0.0",
+            "jsesc": "^1.3.0",
+            "lodash": "^4.17.4",
+            "source-map": "^0.5.7",
+            "trim-right": "^1.0.1"
           },
           "dependencies": {
             "jsesc": {
@@ -3298,9 +3317,9 @@
           "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
           "dev": true,
           "requires": {
-            "babel-helper-explode-assignable-expression": "6.24.1",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-helper-explode-assignable-expression": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-helper-call-delegate": {
@@ -3309,10 +3328,10 @@
           "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
           "dev": true,
           "requires": {
-            "babel-helper-hoist-variables": "6.24.1",
-            "babel-runtime": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-helper-hoist-variables": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-helper-define-map": {
@@ -3321,10 +3340,10 @@
           "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
           "dev": true,
           "requires": {
-            "babel-helper-function-name": "6.24.1",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "lodash": "4.17.20"
+            "babel-helper-function-name": "^6.24.1",
+            "babel-runtime": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "lodash": "^4.17.4"
           }
         },
         "babel-helper-explode-assignable-expression": {
@@ -3333,9 +3352,9 @@
           "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-runtime": "^6.22.0",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-helper-function-name": {
@@ -3344,11 +3363,11 @@
           "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
           "dev": true,
           "requires": {
-            "babel-helper-get-function-arity": "6.24.1",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-helper-get-function-arity": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-helper-get-function-arity": {
@@ -3357,8 +3376,8 @@
           "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-helper-hoist-variables": {
@@ -3367,8 +3386,8 @@
           "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-helper-optimise-call-expression": {
@@ -3377,8 +3396,8 @@
           "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-helper-regex": {
@@ -3387,9 +3406,9 @@
           "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "lodash": "4.17.20"
+            "babel-runtime": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "lodash": "^4.17.4"
           }
         },
         "babel-helper-remap-async-to-generator": {
@@ -3398,11 +3417,11 @@
           "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
           "dev": true,
           "requires": {
-            "babel-helper-function-name": "6.24.1",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-helper-function-name": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-helper-replace-supers": {
@@ -3411,12 +3430,12 @@
           "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
           "dev": true,
           "requires": {
-            "babel-helper-optimise-call-expression": "6.24.1",
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-helper-optimise-call-expression": "^6.24.1",
+            "babel-messages": "^6.23.0",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-helpers": {
@@ -3425,8 +3444,8 @@
           "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0"
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1"
           }
         },
         "babel-messages": {
@@ -3435,7 +3454,7 @@
           "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0"
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-check-es2015-constants": {
@@ -3444,7 +3463,7 @@
           "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0"
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-syntax-async-functions": {
@@ -3471,9 +3490,9 @@
           "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
           "dev": true,
           "requires": {
-            "babel-helper-remap-async-to-generator": "6.24.1",
-            "babel-plugin-syntax-async-functions": "6.13.0",
-            "babel-runtime": "6.26.0"
+            "babel-helper-remap-async-to-generator": "^6.24.1",
+            "babel-plugin-syntax-async-functions": "^6.8.0",
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-transform-es2015-arrow-functions": {
@@ -3482,7 +3501,7 @@
           "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0"
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-transform-es2015-block-scoped-functions": {
@@ -3491,7 +3510,7 @@
           "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0"
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-transform-es2015-block-scoping": {
@@ -3500,11 +3519,11 @@
           "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0",
-            "lodash": "4.17.20"
+            "babel-runtime": "^6.26.0",
+            "babel-template": "^6.26.0",
+            "babel-traverse": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "lodash": "^4.17.4"
           }
         },
         "babel-plugin-transform-es2015-classes": {
@@ -3513,15 +3532,15 @@
           "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
           "dev": true,
           "requires": {
-            "babel-helper-define-map": "6.26.0",
-            "babel-helper-function-name": "6.24.1",
-            "babel-helper-optimise-call-expression": "6.24.1",
-            "babel-helper-replace-supers": "6.24.1",
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-helper-define-map": "^6.24.1",
+            "babel-helper-function-name": "^6.24.1",
+            "babel-helper-optimise-call-expression": "^6.24.1",
+            "babel-helper-replace-supers": "^6.24.1",
+            "babel-messages": "^6.23.0",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-plugin-transform-es2015-computed-properties": {
@@ -3530,8 +3549,8 @@
           "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0"
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1"
           }
         },
         "babel-plugin-transform-es2015-destructuring": {
@@ -3540,7 +3559,7 @@
           "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0"
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-transform-es2015-duplicate-keys": {
@@ -3549,8 +3568,8 @@
           "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-plugin-transform-es2015-for-of": {
@@ -3559,7 +3578,7 @@
           "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0"
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-transform-es2015-function-name": {
@@ -3568,9 +3587,9 @@
           "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
           "dev": true,
           "requires": {
-            "babel-helper-function-name": "6.24.1",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-helper-function-name": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-plugin-transform-es2015-literals": {
@@ -3579,7 +3598,7 @@
           "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0"
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-transform-es2015-modules-amd": {
@@ -3588,9 +3607,9 @@
           "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
           "dev": true,
           "requires": {
-            "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0"
+            "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1"
           }
         },
         "babel-plugin-transform-es2015-modules-commonjs": {
@@ -3599,10 +3618,10 @@
           "integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
           "dev": true,
           "requires": {
-            "babel-plugin-transform-strict-mode": "6.24.1",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-plugin-transform-strict-mode": "^6.24.1",
+            "babel-runtime": "^6.26.0",
+            "babel-template": "^6.26.0",
+            "babel-types": "^6.26.0"
           }
         },
         "babel-plugin-transform-es2015-modules-systemjs": {
@@ -3611,9 +3630,9 @@
           "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
           "dev": true,
           "requires": {
-            "babel-helper-hoist-variables": "6.24.1",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0"
+            "babel-helper-hoist-variables": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1"
           }
         },
         "babel-plugin-transform-es2015-modules-umd": {
@@ -3622,9 +3641,9 @@
           "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
           "dev": true,
           "requires": {
-            "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0"
+            "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1"
           }
         },
         "babel-plugin-transform-es2015-object-super": {
@@ -3633,8 +3652,8 @@
           "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
           "dev": true,
           "requires": {
-            "babel-helper-replace-supers": "6.24.1",
-            "babel-runtime": "6.26.0"
+            "babel-helper-replace-supers": "^6.24.1",
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-transform-es2015-parameters": {
@@ -3643,12 +3662,12 @@
           "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
           "dev": true,
           "requires": {
-            "babel-helper-call-delegate": "6.24.1",
-            "babel-helper-get-function-arity": "6.24.1",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-helper-call-delegate": "^6.24.1",
+            "babel-helper-get-function-arity": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-plugin-transform-es2015-shorthand-properties": {
@@ -3657,8 +3676,8 @@
           "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-plugin-transform-es2015-spread": {
@@ -3667,7 +3686,7 @@
           "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0"
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-transform-es2015-sticky-regex": {
@@ -3676,9 +3695,9 @@
           "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
           "dev": true,
           "requires": {
-            "babel-helper-regex": "6.26.0",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-helper-regex": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-plugin-transform-es2015-template-literals": {
@@ -3687,7 +3706,7 @@
           "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0"
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-transform-es2015-typeof-symbol": {
@@ -3696,7 +3715,7 @@
           "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0"
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-transform-es2015-unicode-regex": {
@@ -3705,9 +3724,9 @@
           "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
           "dev": true,
           "requires": {
-            "babel-helper-regex": "6.26.0",
-            "babel-runtime": "6.26.0",
-            "regexpu-core": "2.0.0"
+            "babel-helper-regex": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "regexpu-core": "^2.0.0"
           }
         },
         "babel-plugin-transform-exponentiation-operator": {
@@ -3716,9 +3735,9 @@
           "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
           "dev": true,
           "requires": {
-            "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
-            "babel-plugin-syntax-exponentiation-operator": "6.13.0",
-            "babel-runtime": "6.26.0"
+            "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
+            "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-transform-regenerator": {
@@ -3727,7 +3746,7 @@
           "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
           "dev": true,
           "requires": {
-            "regenerator-transform": "0.10.1"
+            "regenerator-transform": "^0.10.0"
           }
         },
         "babel-plugin-transform-strict-mode": {
@@ -3736,8 +3755,8 @@
           "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-preset-env": {
@@ -3746,36 +3765,36 @@
           "integrity": "sha512-9OR2afuKDneX2/q2EurSftUYM0xGu4O2D9adAhVfADDhrYDaxXV0rBbevVYoY9n6nyX1PmQW/0jtpJvUNr9CHg==",
           "dev": true,
           "requires": {
-            "babel-plugin-check-es2015-constants": "6.22.0",
-            "babel-plugin-syntax-trailing-function-commas": "6.22.0",
-            "babel-plugin-transform-async-to-generator": "6.24.1",
-            "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-            "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-            "babel-plugin-transform-es2015-block-scoping": "6.26.0",
-            "babel-plugin-transform-es2015-classes": "6.24.1",
-            "babel-plugin-transform-es2015-computed-properties": "6.24.1",
-            "babel-plugin-transform-es2015-destructuring": "6.23.0",
-            "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
-            "babel-plugin-transform-es2015-for-of": "6.23.0",
-            "babel-plugin-transform-es2015-function-name": "6.24.1",
-            "babel-plugin-transform-es2015-literals": "6.22.0",
-            "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-            "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
-            "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
-            "babel-plugin-transform-es2015-modules-umd": "6.24.1",
-            "babel-plugin-transform-es2015-object-super": "6.24.1",
-            "babel-plugin-transform-es2015-parameters": "6.24.1",
-            "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-            "babel-plugin-transform-es2015-spread": "6.22.0",
-            "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-            "babel-plugin-transform-es2015-template-literals": "6.22.0",
-            "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-            "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-            "babel-plugin-transform-exponentiation-operator": "6.24.1",
-            "babel-plugin-transform-regenerator": "6.26.0",
-            "browserslist": "3.2.8",
-            "invariant": "2.2.4",
-            "semver": "5.7.1"
+            "babel-plugin-check-es2015-constants": "^6.22.0",
+            "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
+            "babel-plugin-transform-async-to-generator": "^6.22.0",
+            "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
+            "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
+            "babel-plugin-transform-es2015-block-scoping": "^6.23.0",
+            "babel-plugin-transform-es2015-classes": "^6.23.0",
+            "babel-plugin-transform-es2015-computed-properties": "^6.22.0",
+            "babel-plugin-transform-es2015-destructuring": "^6.23.0",
+            "babel-plugin-transform-es2015-duplicate-keys": "^6.22.0",
+            "babel-plugin-transform-es2015-for-of": "^6.23.0",
+            "babel-plugin-transform-es2015-function-name": "^6.22.0",
+            "babel-plugin-transform-es2015-literals": "^6.22.0",
+            "babel-plugin-transform-es2015-modules-amd": "^6.22.0",
+            "babel-plugin-transform-es2015-modules-commonjs": "^6.23.0",
+            "babel-plugin-transform-es2015-modules-systemjs": "^6.23.0",
+            "babel-plugin-transform-es2015-modules-umd": "^6.23.0",
+            "babel-plugin-transform-es2015-object-super": "^6.22.0",
+            "babel-plugin-transform-es2015-parameters": "^6.23.0",
+            "babel-plugin-transform-es2015-shorthand-properties": "^6.22.0",
+            "babel-plugin-transform-es2015-spread": "^6.22.0",
+            "babel-plugin-transform-es2015-sticky-regex": "^6.22.0",
+            "babel-plugin-transform-es2015-template-literals": "^6.22.0",
+            "babel-plugin-transform-es2015-typeof-symbol": "^6.23.0",
+            "babel-plugin-transform-es2015-unicode-regex": "^6.22.0",
+            "babel-plugin-transform-exponentiation-operator": "^6.22.0",
+            "babel-plugin-transform-regenerator": "^6.22.0",
+            "browserslist": "^3.2.6",
+            "invariant": "^2.2.2",
+            "semver": "^5.3.0"
           },
           "dependencies": {
             "semver": {
@@ -3792,13 +3811,13 @@
           "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
           "dev": true,
           "requires": {
-            "babel-core": "6.26.3",
-            "babel-runtime": "6.26.0",
-            "core-js": "2.6.12",
-            "home-or-tmp": "2.0.0",
-            "lodash": "4.17.20",
-            "mkdirp": "0.5.5",
-            "source-map-support": "0.4.18"
+            "babel-core": "^6.26.0",
+            "babel-runtime": "^6.26.0",
+            "core-js": "^2.5.0",
+            "home-or-tmp": "^2.0.0",
+            "lodash": "^4.17.4",
+            "mkdirp": "^0.5.1",
+            "source-map-support": "^0.4.15"
           },
           "dependencies": {
             "source-map-support": {
@@ -3807,7 +3826,7 @@
               "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
               "dev": true,
               "requires": {
-                "source-map": "0.5.7"
+                "source-map": "^0.5.6"
               }
             }
           }
@@ -3818,8 +3837,8 @@
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
           "dev": true,
           "requires": {
-            "core-js": "2.6.12",
-            "regenerator-runtime": "0.11.1"
+            "core-js": "^2.4.0",
+            "regenerator-runtime": "^0.11.0"
           }
         },
         "babel-template": {
@@ -3828,11 +3847,11 @@
           "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "lodash": "4.17.20"
+            "babel-runtime": "^6.26.0",
+            "babel-traverse": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "babylon": "^6.18.0",
+            "lodash": "^4.17.4"
           }
         },
         "babel-traverse": {
@@ -3841,15 +3860,15 @@
           "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
           "dev": true,
           "requires": {
-            "babel-code-frame": "6.26.0",
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "debug": "2.6.9",
-            "globals": "9.18.0",
-            "invariant": "2.2.4",
-            "lodash": "4.17.20"
+            "babel-code-frame": "^6.26.0",
+            "babel-messages": "^6.23.0",
+            "babel-runtime": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "babylon": "^6.18.0",
+            "debug": "^2.6.8",
+            "globals": "^9.18.0",
+            "invariant": "^2.2.2",
+            "lodash": "^4.17.4"
           },
           "dependencies": {
             "debug": {
@@ -3881,10 +3900,10 @@
           "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "esutils": "2.0.3",
-            "lodash": "4.17.20",
-            "to-fast-properties": "1.0.3"
+            "babel-runtime": "^6.26.0",
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.4",
+            "to-fast-properties": "^1.0.3"
           },
           "dependencies": {
             "to-fast-properties": {
@@ -3901,8 +3920,8 @@
           "integrity": "sha1-qlau3nBn/XvVSWZu4W3ChQh+iOU=",
           "dev": true,
           "requires": {
-            "babel-core": "6.26.3",
-            "object-assign": "4.1.1"
+            "babel-core": "^6.0.14",
+            "object-assign": "^4.0.0"
           }
         },
         "babylon": {
@@ -3917,7 +3936,7 @@
           "integrity": "sha1-9hbtqdPktmuMp/ynn2lXIsX44m8=",
           "dev": true,
           "requires": {
-            "precond": "0.2.3"
+            "precond": "0.2"
           }
         },
         "balanced-match": {
@@ -3932,13 +3951,13 @@
           "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
           "dev": true,
           "requires": {
-            "cache-base": "1.0.1",
-            "class-utils": "0.3.6",
-            "component-emitter": "1.3.0",
-            "define-property": "1.0.0",
-            "isobject": "3.0.1",
-            "mixin-deep": "1.3.2",
-            "pascalcase": "0.1.1"
+            "cache-base": "^1.0.1",
+            "class-utils": "^0.3.5",
+            "component-emitter": "^1.2.1",
+            "define-property": "^1.0.0",
+            "isobject": "^3.0.1",
+            "mixin-deep": "^1.2.0",
+            "pascalcase": "^0.1.1"
           },
           "dependencies": {
             "define-property": {
@@ -3947,7 +3966,7 @@
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "1.0.2"
+                "is-descriptor": "^1.0.0"
               }
             }
           }
@@ -3958,7 +3977,7 @@
           "integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.2.1"
+            "safe-buffer": "^5.0.1"
           }
         },
         "base64-js": {
@@ -3973,7 +3992,7 @@
           "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
           "dev": true,
           "requires": {
-            "tweetnacl": "0.14.5"
+            "tweetnacl": "^0.14.3"
           },
           "dependencies": {
             "tweetnacl": {
@@ -3988,7 +4007,8 @@
           "version": "9.0.1",
           "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
           "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "bip39": {
           "version": "2.5.0",
@@ -3996,11 +4016,11 @@
           "integrity": "sha512-xwIx/8JKoT2+IPJpFEfXoWdYwP7UVAoUxxLNfGCfVowaJE7yg1Y5B1BVPqlUNsBq5/nGwmFkwRJ8xDW4sX8OdA==",
           "dev": true,
           "requires": {
-            "create-hash": "1.2.0",
-            "pbkdf2": "3.1.1",
-            "randombytes": "2.1.0",
-            "safe-buffer": "5.2.1",
-            "unorm": "1.6.0"
+            "create-hash": "^1.1.0",
+            "pbkdf2": "^3.0.9",
+            "randombytes": "^2.0.1",
+            "safe-buffer": "^5.0.1",
+            "unorm": "^1.3.3"
           }
         },
         "blakejs": {
@@ -4027,17 +4047,18 @@
           "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
           "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "bytes": "3.1.0",
-            "content-type": "1.0.4",
+            "content-type": "~1.0.4",
             "debug": "2.6.9",
-            "depd": "1.1.2",
+            "depd": "~1.1.2",
             "http-errors": "1.7.2",
             "iconv-lite": "0.4.24",
-            "on-finished": "2.3.0",
+            "on-finished": "~2.3.0",
             "qs": "6.7.0",
             "raw-body": "2.4.0",
-            "type-is": "1.6.18"
+            "type-is": "~1.6.17"
           },
           "dependencies": {
             "debug": {
@@ -4045,6 +4066,7 @@
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
               "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
               "dev": true,
+              "optional": true,
               "requires": {
                 "ms": "2.0.0"
               }
@@ -4053,13 +4075,15 @@
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
               "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "qs": {
               "version": "6.7.0",
               "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
               "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -4069,7 +4093,7 @@
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "requires": {
-            "balanced-match": "1.0.0",
+            "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -4085,12 +4109,12 @@
           "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
           "dev": true,
           "requires": {
-            "buffer-xor": "1.0.3",
-            "cipher-base": "1.0.4",
-            "create-hash": "1.2.0",
-            "evp_bytestokey": "1.0.3",
-            "inherits": "2.0.4",
-            "safe-buffer": "5.2.1"
+            "buffer-xor": "^1.0.3",
+            "cipher-base": "^1.0.0",
+            "create-hash": "^1.1.0",
+            "evp_bytestokey": "^1.0.3",
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.0.1"
           }
         },
         "browserify-cipher": {
@@ -4100,9 +4124,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "browserify-aes": "1.2.0",
-            "browserify-des": "1.0.2",
-            "evp_bytestokey": "1.0.3"
+            "browserify-aes": "^1.0.4",
+            "browserify-des": "^1.0.0",
+            "evp_bytestokey": "^1.0.0"
           }
         },
         "browserify-des": {
@@ -4112,10 +4136,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "cipher-base": "1.0.4",
-            "des.js": "1.0.1",
-            "inherits": "2.0.4",
-            "safe-buffer": "5.2.1"
+            "cipher-base": "^1.0.1",
+            "des.js": "^1.0.0",
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.1.2"
           }
         },
         "browserify-rsa": {
@@ -4123,16 +4147,18 @@
           "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.1.0.tgz",
           "integrity": "sha512-AdEER0Hkspgno2aR97SAf6vi0y0k8NuOpGnVH3O99rcA5Q6sh8QxcngtHuJ6uXwnfAXNM4Gn1Gb7/MV1+Ymbog==",
           "dev": true,
+          "optional": true,
           "requires": {
-            "bn.js": "5.1.3",
-            "randombytes": "2.1.0"
+            "bn.js": "^5.0.0",
+            "randombytes": "^2.0.1"
           },
           "dependencies": {
             "bn.js": {
               "version": "5.1.3",
               "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.3.tgz",
               "integrity": "sha512-GkTiFpjFtUzU9CbMeJ5iazkCzGL3jrhzerzZIuqLABjbwRaFt33I9tUdSNryIptM+RxDet6OKm2WnLXzW51KsQ==",
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -4143,15 +4169,15 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "bn.js": "5.1.3",
-            "browserify-rsa": "4.1.0",
-            "create-hash": "1.2.0",
-            "create-hmac": "1.1.7",
-            "elliptic": "6.5.3",
-            "inherits": "2.0.4",
-            "parse-asn1": "5.1.6",
-            "readable-stream": "3.6.0",
-            "safe-buffer": "5.2.1"
+            "bn.js": "^5.1.1",
+            "browserify-rsa": "^4.0.1",
+            "create-hash": "^1.2.0",
+            "create-hmac": "^1.1.7",
+            "elliptic": "^6.5.3",
+            "inherits": "^2.0.4",
+            "parse-asn1": "^5.1.5",
+            "readable-stream": "^3.6.0",
+            "safe-buffer": "^5.2.0"
           },
           "dependencies": {
             "bn.js": {
@@ -4168,9 +4194,9 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "inherits": "2.0.4",
-                "string_decoder": "1.1.1",
-                "util-deprecate": "1.0.2"
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
               }
             }
           }
@@ -4181,8 +4207,8 @@
           "integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
           "dev": true,
           "requires": {
-            "caniuse-lite": "1.0.30001174",
-            "electron-to-chromium": "1.3.636"
+            "caniuse-lite": "^1.0.30000844",
+            "electron-to-chromium": "^1.3.47"
           }
         },
         "bs58": {
@@ -4191,7 +4217,7 @@
           "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
           "dev": true,
           "requires": {
-            "base-x": "3.0.8"
+            "base-x": "^3.0.2"
           }
         },
         "bs58check": {
@@ -4200,9 +4226,9 @@
           "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
           "dev": true,
           "requires": {
-            "bs58": "4.0.1",
-            "create-hash": "1.2.0",
-            "safe-buffer": "5.2.1"
+            "bs58": "^4.0.0",
+            "create-hash": "^1.1.0",
+            "safe-buffer": "^5.1.2"
           }
         },
         "buffer": {
@@ -4211,8 +4237,8 @@
           "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
           "dev": true,
           "requires": {
-            "base64-js": "1.5.1",
-            "ieee754": "1.2.1"
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.1.13"
           }
         },
         "buffer-from": {
@@ -4225,7 +4251,8 @@
           "version": "0.0.5",
           "resolved": "https://registry.npmjs.org/buffer-to-arraybuffer/-/buffer-to-arraybuffer-0.0.5.tgz",
           "integrity": "sha1-YGSkD6dutDxyOrqe+PbhIW0QURo=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "buffer-xor": {
           "version": "1.0.3",
@@ -4239,14 +4266,15 @@
           "integrity": "sha512-yEYTwGndELGvfXsImMBLop58eaGW+YdONi1fNjTINSY98tmMmFijBG6WXgdkfuLNt4imzQNtIE+eBp1PVpMCSw==",
           "dev": true,
           "requires": {
-            "node-gyp-build": "4.2.3"
+            "node-gyp-build": "^4.2.0"
           }
         },
         "bytes": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
           "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "bytewise": {
           "version": "1.1.0",
@@ -4254,8 +4282,8 @@
           "integrity": "sha1-HRPL/3F65xWAlKqIGzXQgbOHJT4=",
           "dev": true,
           "requires": {
-            "bytewise-core": "1.2.3",
-            "typewise": "1.0.3"
+            "bytewise-core": "^1.2.2",
+            "typewise": "^1.0.3"
           }
         },
         "bytewise-core": {
@@ -4264,7 +4292,7 @@
           "integrity": "sha1-P7QQx+kVWOsasiqCg0V3qmvWHUI=",
           "dev": true,
           "requires": {
-            "typewise-core": "1.2.0"
+            "typewise-core": "^1.2"
           }
         },
         "cache-base": {
@@ -4273,15 +4301,15 @@
           "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
           "dev": true,
           "requires": {
-            "collection-visit": "1.0.0",
-            "component-emitter": "1.3.0",
-            "get-value": "2.0.6",
-            "has-value": "1.0.0",
-            "isobject": "3.0.1",
-            "set-value": "2.0.1",
-            "to-object-path": "0.3.0",
-            "union-value": "1.0.1",
-            "unset-value": "1.0.0"
+            "collection-visit": "^1.0.0",
+            "component-emitter": "^1.2.1",
+            "get-value": "^2.0.6",
+            "has-value": "^1.0.0",
+            "isobject": "^3.0.1",
+            "set-value": "^2.0.0",
+            "to-object-path": "^0.3.0",
+            "union-value": "^1.0.0",
+            "unset-value": "^1.0.0"
           }
         },
         "cacheable-request": {
@@ -4291,13 +4319,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "clone-response": "1.0.2",
-            "get-stream": "5.2.0",
-            "http-cache-semantics": "4.1.0",
-            "keyv": "3.1.0",
-            "lowercase-keys": "2.0.0",
-            "normalize-url": "4.5.0",
-            "responselike": "1.0.2"
+            "clone-response": "^1.0.2",
+            "get-stream": "^5.1.0",
+            "http-cache-semantics": "^4.0.0",
+            "keyv": "^3.0.0",
+            "lowercase-keys": "^2.0.0",
+            "normalize-url": "^4.1.0",
+            "responselike": "^1.0.2"
           },
           "dependencies": {
             "lowercase-keys": {
@@ -4315,8 +4343,8 @@
           "integrity": "sha1-1D8DbkUQaWsxJG19sx6/D3rDLRU=",
           "dev": true,
           "requires": {
-            "abstract-leveldown": "2.7.2",
-            "lru-cache": "3.2.0"
+            "abstract-leveldown": "^2.4.1",
+            "lru-cache": "^3.2.0"
           },
           "dependencies": {
             "abstract-leveldown": {
@@ -4325,7 +4353,7 @@
               "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
               "dev": true,
               "requires": {
-                "xtend": "4.0.2"
+                "xtend": "~4.0.0"
               }
             },
             "lru-cache": {
@@ -4334,7 +4362,7 @@
               "integrity": "sha1-cXibO39Tmb7IVl3aOKow0qCX7+4=",
               "dev": true,
               "requires": {
-                "pseudomap": "1.0.2"
+                "pseudomap": "^1.0.1"
               }
             }
           }
@@ -4345,8 +4373,8 @@
           "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
           "dev": true,
           "requires": {
-            "function-bind": "1.1.1",
-            "get-intrinsic": "1.0.2"
+            "function-bind": "^1.1.1",
+            "get-intrinsic": "^1.0.2"
           }
         },
         "caniuse-lite": {
@@ -4367,9 +4395,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.5.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "checkpoint-store": {
@@ -4378,7 +4406,7 @@
           "integrity": "sha1-BOTLUWuRQziTWB5tRgGnjpVS6gY=",
           "dev": true,
           "requires": {
-            "functional-red-black-tree": "1.0.1"
+            "functional-red-black-tree": "^1.0.1"
           }
         },
         "chownr": {
@@ -4401,11 +4429,11 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "buffer": "5.7.1",
-            "class-is": "1.1.0",
-            "multibase": "0.6.1",
-            "multicodec": "1.0.4",
-            "multihashes": "0.4.21"
+            "buffer": "^5.5.0",
+            "class-is": "^1.1.0",
+            "multibase": "~0.6.0",
+            "multicodec": "^1.0.0",
+            "multihashes": "~0.4.15"
           },
           "dependencies": {
             "multicodec": {
@@ -4415,8 +4443,8 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "buffer": "5.7.1",
-                "varint": "5.0.2"
+                "buffer": "^5.6.0",
+                "varint": "^5.0.0"
               }
             }
           }
@@ -4427,8 +4455,8 @@
           "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
           "dev": true,
           "requires": {
-            "inherits": "2.0.4",
-            "safe-buffer": "5.2.1"
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.0.1"
           }
         },
         "class-is": {
@@ -4444,10 +4472,10 @@
           "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
           "dev": true,
           "requires": {
-            "arr-union": "3.1.0",
-            "define-property": "0.2.5",
-            "isobject": "3.0.1",
-            "static-extend": "0.1.2"
+            "arr-union": "^3.1.0",
+            "define-property": "^0.2.5",
+            "isobject": "^3.0.0",
+            "static-extend": "^0.1.1"
           },
           "dependencies": {
             "define-property": {
@@ -4456,7 +4484,7 @@
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "0.1.6"
+                "is-descriptor": "^0.1.0"
               }
             },
             "is-accessor-descriptor": {
@@ -4465,7 +4493,7 @@
               "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
               "dev": true,
               "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -4474,7 +4502,7 @@
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
-                    "is-buffer": "1.1.6"
+                    "is-buffer": "^1.1.5"
                   }
                 }
               }
@@ -4491,7 +4519,7 @@
               "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
               "dev": true,
               "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -4500,7 +4528,7 @@
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
-                    "is-buffer": "1.1.6"
+                    "is-buffer": "^1.1.5"
                   }
                 }
               }
@@ -4511,9 +4539,9 @@
               "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "0.1.6",
-                "is-data-descriptor": "0.1.4",
-                "kind-of": "5.1.0"
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
               }
             },
             "kind-of": {
@@ -4537,7 +4565,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "mimic-response": "1.0.1"
+            "mimic-response": "^1.0.0"
           }
         },
         "collection-visit": {
@@ -4546,8 +4574,8 @@
           "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
           "dev": true,
           "requires": {
-            "map-visit": "1.0.0",
-            "object-visit": "1.0.1"
+            "map-visit": "^1.0.0",
+            "object-visit": "^1.0.0"
           }
         },
         "color-convert": {
@@ -4571,7 +4599,7 @@
           "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
           "dev": true,
           "requires": {
-            "delayed-stream": "1.0.0"
+            "delayed-stream": "~1.0.0"
           }
         },
         "component-emitter": {
@@ -4592,10 +4620,10 @@
           "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
           "dev": true,
           "requires": {
-            "buffer-from": "1.1.1",
-            "inherits": "2.0.4",
-            "readable-stream": "2.3.7",
-            "typedarray": "0.0.6"
+            "buffer-from": "^1.0.0",
+            "inherits": "^2.0.3",
+            "readable-stream": "^2.2.2",
+            "typedarray": "^0.0.6"
           }
         },
         "content-disposition": {
@@ -4624,16 +4652,17 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "cids": "0.7.5",
-            "multicodec": "0.5.7",
-            "multihashes": "0.4.21"
+            "cids": "^0.7.1",
+            "multicodec": "^0.5.5",
+            "multihashes": "^0.4.15"
           }
         },
         "content-type": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
           "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "convert-source-map": {
           "version": "1.7.0",
@@ -4641,7 +4670,7 @@
           "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.2"
+            "safe-buffer": "~5.1.1"
           },
           "dependencies": {
             "safe-buffer": {
@@ -4670,7 +4699,8 @@
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
           "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "copy-descriptor": {
           "version": "0.1.1",
@@ -4703,8 +4733,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "object-assign": "4.1.1",
-            "vary": "1.1.2"
+            "object-assign": "^4",
+            "vary": "^1"
           }
         },
         "create-ecdh": {
@@ -4714,8 +4744,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "bn.js": "4.11.9",
-            "elliptic": "6.5.3"
+            "bn.js": "^4.1.0",
+            "elliptic": "^6.5.3"
           }
         },
         "create-hash": {
@@ -4724,11 +4754,11 @@
           "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
           "dev": true,
           "requires": {
-            "cipher-base": "1.0.4",
-            "inherits": "2.0.4",
-            "md5.js": "1.3.5",
-            "ripemd160": "2.0.2",
-            "sha.js": "2.4.11"
+            "cipher-base": "^1.0.1",
+            "inherits": "^2.0.1",
+            "md5.js": "^1.3.4",
+            "ripemd160": "^2.0.1",
+            "sha.js": "^2.4.0"
           }
         },
         "create-hmac": {
@@ -4737,12 +4767,12 @@
           "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
           "dev": true,
           "requires": {
-            "cipher-base": "1.0.4",
-            "create-hash": "1.2.0",
-            "inherits": "2.0.4",
-            "ripemd160": "2.0.2",
-            "safe-buffer": "5.2.1",
-            "sha.js": "2.4.11"
+            "cipher-base": "^1.0.3",
+            "create-hash": "^1.1.0",
+            "inherits": "^2.0.1",
+            "ripemd160": "^2.0.0",
+            "safe-buffer": "^5.0.1",
+            "sha.js": "^2.4.8"
           }
         },
         "cross-fetch": {
@@ -4762,17 +4792,17 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "browserify-cipher": "1.0.1",
-            "browserify-sign": "4.2.1",
-            "create-ecdh": "4.0.4",
-            "create-hash": "1.2.0",
-            "create-hmac": "1.1.7",
-            "diffie-hellman": "5.0.3",
-            "inherits": "2.0.4",
-            "pbkdf2": "3.1.1",
-            "public-encrypt": "4.0.3",
-            "randombytes": "2.1.0",
-            "randomfill": "1.0.4"
+            "browserify-cipher": "^1.0.0",
+            "browserify-sign": "^4.0.0",
+            "create-ecdh": "^4.0.0",
+            "create-hash": "^1.1.0",
+            "create-hmac": "^1.1.0",
+            "diffie-hellman": "^5.0.0",
+            "inherits": "^2.0.1",
+            "pbkdf2": "^3.0.3",
+            "public-encrypt": "^4.0.0",
+            "randombytes": "^2.0.0",
+            "randomfill": "^1.0.3"
           }
         },
         "d": {
@@ -4781,8 +4811,8 @@
           "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
           "dev": true,
           "requires": {
-            "es5-ext": "0.10.53",
-            "type": "1.2.0"
+            "es5-ext": "^0.10.50",
+            "type": "^1.0.1"
           }
         },
         "dashdash": {
@@ -4791,7 +4821,7 @@
           "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
           "dev": true,
           "requires": {
-            "assert-plus": "1.0.0"
+            "assert-plus": "^1.0.0"
           }
         },
         "debug": {
@@ -4800,7 +4830,7 @@
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "dev": true,
           "requires": {
-            "ms": "2.1.3"
+            "ms": "^2.1.1"
           }
         },
         "decode-uri-component": {
@@ -4814,8 +4844,9 @@
           "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
           "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
           "dev": true,
+          "optional": true,
           "requires": {
-            "mimic-response": "1.0.1"
+            "mimic-response": "^1.0.0"
           }
         },
         "deep-equal": {
@@ -4824,12 +4855,12 @@
           "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
           "dev": true,
           "requires": {
-            "is-arguments": "1.1.0",
-            "is-date-object": "1.0.2",
-            "is-regex": "1.1.1",
-            "object-is": "1.1.4",
-            "object-keys": "1.1.1",
-            "regexp.prototype.flags": "1.3.0"
+            "is-arguments": "^1.0.4",
+            "is-date-object": "^1.0.1",
+            "is-regex": "^1.0.4",
+            "object-is": "^1.0.1",
+            "object-keys": "^1.1.1",
+            "regexp.prototype.flags": "^1.2.0"
           }
         },
         "defer-to-connect": {
@@ -4845,8 +4876,8 @@
           "integrity": "sha512-5fMC8ek8alH16QiV0lTCis610D1Zt1+LA4MS4d63JgS32lrCjTFDUFz2ao09/j2I4Bqb5jL4FZYwu7Jz0XO1ww==",
           "dev": true,
           "requires": {
-            "abstract-leveldown": "5.0.0",
-            "inherits": "2.0.4"
+            "abstract-leveldown": "~5.0.0",
+            "inherits": "^2.0.3"
           },
           "dependencies": {
             "abstract-leveldown": {
@@ -4855,7 +4886,7 @@
               "integrity": "sha512-5mU5P1gXtsMIXg65/rsYGsi93+MlogXZ9FA8JnwKurHQg64bfXwGYVdVdijNTVNOlAsuIiOwHdvFFD5JqCJQ7A==",
               "dev": true,
               "requires": {
-                "xtend": "4.0.2"
+                "xtend": "~4.0.0"
               }
             }
           }
@@ -4866,7 +4897,7 @@
           "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
           "dev": true,
           "requires": {
-            "object-keys": "1.1.1"
+            "object-keys": "^1.0.12"
           }
         },
         "define-property": {
@@ -4875,8 +4906,8 @@
           "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
           "dev": true,
           "requires": {
-            "is-descriptor": "1.0.2",
-            "isobject": "3.0.1"
+            "is-descriptor": "^1.0.2",
+            "isobject": "^3.0.1"
           }
         },
         "defined": {
@@ -4895,7 +4926,8 @@
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
           "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "des.js": {
           "version": "1.0.1",
@@ -4904,15 +4936,16 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "inherits": "2.0.4",
-            "minimalistic-assert": "1.0.1"
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0"
           }
         },
         "destroy": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
           "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "detect-indent": {
           "version": "4.0.0",
@@ -4920,7 +4953,7 @@
           "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
           "dev": true,
           "requires": {
-            "repeating": "2.0.1"
+            "repeating": "^2.0.0"
           }
         },
         "diffie-hellman": {
@@ -4930,9 +4963,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "bn.js": "4.11.9",
-            "miller-rabin": "4.0.1",
-            "randombytes": "2.1.0"
+            "bn.js": "^4.1.0",
+            "miller-rabin": "^4.0.0",
+            "randombytes": "^2.0.0"
           }
         },
         "dom-walk": {
@@ -4947,14 +4980,15 @@
           "integrity": "sha512-UGGGWfSauusaVJC+8fgV+NVvBXkCTmVv7sk6nojDZZvuOUNGUy0Zk4UpHQD6EDjS0jpBwcACvH4eofvyzBcRDw==",
           "dev": true,
           "requires": {
-            "minimatch": "3.0.4"
+            "minimatch": "^3.0.4"
           }
         },
         "duplexer3": {
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
           "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ecc-jsbn": {
           "version": "0.1.2",
@@ -4962,15 +4996,16 @@
           "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
           "dev": true,
           "requires": {
-            "jsbn": "0.1.1",
-            "safer-buffer": "2.1.2"
+            "jsbn": "~0.1.0",
+            "safer-buffer": "^2.1.0"
           }
         },
         "ee-first": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
           "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "electron-to-chromium": {
           "version": "1.3.636",
@@ -4984,20 +5019,21 @@
           "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
           "dev": true,
           "requires": {
-            "bn.js": "4.11.9",
-            "brorand": "1.1.0",
-            "hash.js": "1.1.7",
-            "hmac-drbg": "1.0.1",
-            "inherits": "2.0.4",
-            "minimalistic-assert": "1.0.1",
-            "minimalistic-crypto-utils": "1.0.1"
+            "bn.js": "^4.4.0",
+            "brorand": "^1.0.1",
+            "hash.js": "^1.0.0",
+            "hmac-drbg": "^1.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0",
+            "minimalistic-crypto-utils": "^1.0.0"
           }
         },
         "encodeurl": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
           "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "encoding": {
           "version": "0.1.13",
@@ -5005,7 +5041,7 @@
           "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
           "dev": true,
           "requires": {
-            "iconv-lite": "0.6.2"
+            "iconv-lite": "^0.6.2"
           },
           "dependencies": {
             "iconv-lite": {
@@ -5014,7 +5050,7 @@
               "integrity": "sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==",
               "dev": true,
               "requires": {
-                "safer-buffer": "2.1.2"
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
               }
             }
           }
@@ -5025,11 +5061,11 @@
           "integrity": "sha512-8CIZLDcSKxgzT+zX8ZVfgNbu8Md2wq/iqa1Y7zyVR18QBEAc0Nmzuvj/N5ykSKpfGzjM8qxbaFntLPwnVoUhZw==",
           "dev": true,
           "requires": {
-            "abstract-leveldown": "5.0.0",
-            "inherits": "2.0.4",
-            "level-codec": "9.0.2",
-            "level-errors": "2.0.1",
-            "xtend": "4.0.2"
+            "abstract-leveldown": "^5.0.0",
+            "inherits": "^2.0.3",
+            "level-codec": "^9.0.0",
+            "level-errors": "^2.0.0",
+            "xtend": "^4.0.1"
           },
           "dependencies": {
             "abstract-leveldown": {
@@ -5038,7 +5074,7 @@
               "integrity": "sha512-5mU5P1gXtsMIXg65/rsYGsi93+MlogXZ9FA8JnwKurHQg64bfXwGYVdVdijNTVNOlAsuIiOwHdvFFD5JqCJQ7A==",
               "dev": true,
               "requires": {
-                "xtend": "4.0.2"
+                "xtend": "~4.0.0"
               }
             }
           }
@@ -5049,7 +5085,7 @@
           "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
           "dev": true,
           "requires": {
-            "once": "1.4.0"
+            "once": "^1.4.0"
           }
         },
         "errno": {
@@ -5058,7 +5094,7 @@
           "integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
           "dev": true,
           "requires": {
-            "prr": "1.0.1"
+            "prr": "~1.0.1"
           }
         },
         "es-abstract": {
@@ -5067,18 +5103,18 @@
           "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
           "dev": true,
           "requires": {
-            "es-to-primitive": "1.2.1",
-            "function-bind": "1.1.1",
-            "has": "1.0.3",
-            "has-symbols": "1.0.1",
-            "is-callable": "1.2.2",
-            "is-negative-zero": "2.0.1",
-            "is-regex": "1.1.1",
-            "object-inspect": "1.9.0",
-            "object-keys": "1.1.1",
-            "object.assign": "4.1.2",
-            "string.prototype.trimend": "1.0.3",
-            "string.prototype.trimstart": "1.0.3"
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.2",
+            "is-negative-zero": "^2.0.0",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.8.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.1",
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
           }
         },
         "es-to-primitive": {
@@ -5087,9 +5123,9 @@
           "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
           "dev": true,
           "requires": {
-            "is-callable": "1.2.2",
-            "is-date-object": "1.0.2",
-            "is-symbol": "1.0.3"
+            "is-callable": "^1.1.4",
+            "is-date-object": "^1.0.1",
+            "is-symbol": "^1.0.2"
           }
         },
         "es5-ext": {
@@ -5098,9 +5134,9 @@
           "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
           "dev": true,
           "requires": {
-            "es6-iterator": "2.0.3",
-            "es6-symbol": "3.1.3",
-            "next-tick": "1.0.0"
+            "es6-iterator": "~2.0.3",
+            "es6-symbol": "~3.1.3",
+            "next-tick": "~1.0.0"
           }
         },
         "es6-iterator": {
@@ -5109,9 +5145,9 @@
           "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
           "dev": true,
           "requires": {
-            "d": "1.0.1",
-            "es5-ext": "0.10.53",
-            "es6-symbol": "3.1.3"
+            "d": "1",
+            "es5-ext": "^0.10.35",
+            "es6-symbol": "^3.1.1"
           }
         },
         "es6-symbol": {
@@ -5120,15 +5156,16 @@
           "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
           "dev": true,
           "requires": {
-            "d": "1.0.1",
-            "ext": "1.4.0"
+            "d": "^1.0.1",
+            "ext": "^1.1.2"
           }
         },
         "escape-html": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
           "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "escape-string-regexp": {
           "version": "1.0.5",
@@ -5146,7 +5183,8 @@
           "version": "1.8.1",
           "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
           "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "eth-block-tracker": {
           "version": "3.0.1",
@@ -5154,13 +5192,13 @@
           "integrity": "sha512-WUVxWLuhMmsfenfZvFO5sbl1qFY2IqUlw/FPVmjjdElpqLsZtSG+wPe9Dz7W/sB6e80HgFKknOmKk2eNlznHug==",
           "dev": true,
           "requires": {
-            "eth-query": "2.1.2",
-            "ethereumjs-tx": "1.3.7",
-            "ethereumjs-util": "5.2.1",
-            "ethjs-util": "0.1.6",
-            "json-rpc-engine": "3.8.0",
-            "pify": "2.3.0",
-            "tape": "4.13.3"
+            "eth-query": "^2.1.0",
+            "ethereumjs-tx": "^1.3.3",
+            "ethereumjs-util": "^5.1.3",
+            "ethjs-util": "^0.1.3",
+            "json-rpc-engine": "^3.6.0",
+            "pify": "^2.3.0",
+            "tape": "^4.6.3"
           },
           "dependencies": {
             "ethereumjs-tx": {
@@ -5169,8 +5207,8 @@
               "integrity": "sha512-wvLMxzt1RPhAQ9Yi3/HKZTn0FZYpnsmQdbKYfUUpi4j1SEIcbkd9tndVjcPrufY3V7j2IebOpC00Zp2P/Ay2kA==",
               "dev": true,
               "requires": {
-                "ethereum-common": "0.0.18",
-                "ethereumjs-util": "5.2.1"
+                "ethereum-common": "^0.0.18",
+                "ethereumjs-util": "^5.0.0"
               }
             },
             "ethereumjs-util": {
@@ -5179,13 +5217,13 @@
               "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
               "dev": true,
               "requires": {
-                "bn.js": "4.11.9",
-                "create-hash": "1.2.0",
-                "elliptic": "6.5.3",
-                "ethereum-cryptography": "0.1.3",
-                "ethjs-util": "0.1.6",
-                "rlp": "2.2.6",
-                "safe-buffer": "5.2.1"
+                "bn.js": "^4.11.0",
+                "create-hash": "^1.1.2",
+                "elliptic": "^6.5.2",
+                "ethereum-cryptography": "^0.1.3",
+                "ethjs-util": "^0.1.3",
+                "rlp": "^2.0.0",
+                "safe-buffer": "^5.1.1"
               }
             },
             "pify": {
@@ -5203,8 +5241,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "idna-uts46-hx": "2.3.1",
-            "js-sha3": "0.5.7"
+            "idna-uts46-hx": "^2.3.1",
+            "js-sha3": "^0.5.7"
           }
         },
         "eth-json-rpc-infura": {
@@ -5213,10 +5251,10 @@
           "integrity": "sha512-W7zR4DZvyTn23Bxc0EWsq4XGDdD63+XPUCEhV2zQvQGavDVC4ZpFDK4k99qN7bd7/fjj37+rxmuBOBeIqCA5Mw==",
           "dev": true,
           "requires": {
-            "cross-fetch": "2.2.3",
-            "eth-json-rpc-middleware": "1.6.0",
-            "json-rpc-engine": "3.8.0",
-            "json-rpc-error": "2.0.0"
+            "cross-fetch": "^2.1.1",
+            "eth-json-rpc-middleware": "^1.5.0",
+            "json-rpc-engine": "^3.4.0",
+            "json-rpc-error": "^2.0.0"
           }
         },
         "eth-json-rpc-middleware": {
@@ -5225,19 +5263,19 @@
           "integrity": "sha512-tDVCTlrUvdqHKqivYMjtFZsdD7TtpNLBCfKAcOpaVs7orBMS/A8HWro6dIzNtTZIR05FAbJ3bioFOnZpuCew9Q==",
           "dev": true,
           "requires": {
-            "async": "2.6.2",
-            "eth-query": "2.1.2",
-            "eth-tx-summary": "3.2.4",
-            "ethereumjs-block": "1.7.1",
-            "ethereumjs-tx": "1.3.7",
-            "ethereumjs-util": "5.2.1",
-            "ethereumjs-vm": "2.6.0",
-            "fetch-ponyfill": "4.1.0",
-            "json-rpc-engine": "3.8.0",
-            "json-rpc-error": "2.0.0",
-            "json-stable-stringify": "1.0.1",
-            "promise-to-callback": "1.0.0",
-            "tape": "4.13.3"
+            "async": "^2.5.0",
+            "eth-query": "^2.1.2",
+            "eth-tx-summary": "^3.1.2",
+            "ethereumjs-block": "^1.6.0",
+            "ethereumjs-tx": "^1.3.3",
+            "ethereumjs-util": "^5.1.2",
+            "ethereumjs-vm": "^2.1.0",
+            "fetch-ponyfill": "^4.0.0",
+            "json-rpc-engine": "^3.6.0",
+            "json-rpc-error": "^2.0.0",
+            "json-stable-stringify": "^1.0.1",
+            "promise-to-callback": "^1.0.0",
+            "tape": "^4.6.3"
           },
           "dependencies": {
             "abstract-leveldown": {
@@ -5246,7 +5284,7 @@
               "integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
               "dev": true,
               "requires": {
-                "xtend": "4.0.2"
+                "xtend": "~4.0.0"
               }
             },
             "deferred-leveldown": {
@@ -5255,7 +5293,7 @@
               "integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
               "dev": true,
               "requires": {
-                "abstract-leveldown": "2.6.3"
+                "abstract-leveldown": "~2.6.0"
               }
             },
             "ethereumjs-account": {
@@ -5264,9 +5302,9 @@
               "integrity": "sha512-bgDojnXGjhMwo6eXQC0bY6UK2liSFUSMwwylOmQvZbSl/D7NXQ3+vrGO46ZeOgjGfxXmgIeVNDIiHw7fNZM4VA==",
               "dev": true,
               "requires": {
-                "ethereumjs-util": "5.2.1",
-                "rlp": "2.2.6",
-                "safe-buffer": "5.1.2"
+                "ethereumjs-util": "^5.0.0",
+                "rlp": "^2.0.0",
+                "safe-buffer": "^5.1.1"
               }
             },
             "ethereumjs-block": {
@@ -5275,11 +5313,11 @@
               "integrity": "sha512-B+sSdtqm78fmKkBq78/QLKJbu/4Ts4P2KFISdgcuZUPDm9x+N7qgBPIIFUGbaakQh8bzuquiRVbdmvPKqbILRg==",
               "dev": true,
               "requires": {
-                "async": "2.6.2",
+                "async": "^2.0.1",
                 "ethereum-common": "0.2.0",
-                "ethereumjs-tx": "1.3.7",
-                "ethereumjs-util": "5.2.1",
-                "merkle-patricia-tree": "2.3.2"
+                "ethereumjs-tx": "^1.2.2",
+                "ethereumjs-util": "^5.0.0",
+                "merkle-patricia-tree": "^2.1.2"
               },
               "dependencies": {
                 "ethereum-common": {
@@ -5296,8 +5334,8 @@
               "integrity": "sha512-wvLMxzt1RPhAQ9Yi3/HKZTn0FZYpnsmQdbKYfUUpi4j1SEIcbkd9tndVjcPrufY3V7j2IebOpC00Zp2P/Ay2kA==",
               "dev": true,
               "requires": {
-                "ethereum-common": "0.0.18",
-                "ethereumjs-util": "5.2.1"
+                "ethereum-common": "^0.0.18",
+                "ethereumjs-util": "^5.0.0"
               }
             },
             "ethereumjs-util": {
@@ -5306,13 +5344,13 @@
               "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
               "dev": true,
               "requires": {
-                "bn.js": "4.11.9",
-                "create-hash": "1.2.0",
-                "elliptic": "6.5.3",
-                "ethereum-cryptography": "0.1.3",
-                "ethjs-util": "0.1.6",
-                "rlp": "2.2.6",
-                "safe-buffer": "5.1.2"
+                "bn.js": "^4.11.0",
+                "create-hash": "^1.1.2",
+                "elliptic": "^6.5.2",
+                "ethereum-cryptography": "^0.1.3",
+                "ethjs-util": "^0.1.3",
+                "rlp": "^2.0.0",
+                "safe-buffer": "^5.1.1"
               }
             },
             "ethereumjs-vm": {
@@ -5321,17 +5359,17 @@
               "integrity": "sha512-r/XIUik/ynGbxS3y+mvGnbOKnuLo40V5Mj1J25+HEO63aWYREIqvWeRO/hnROlMBE5WoniQmPmhiaN0ctiHaXw==",
               "dev": true,
               "requires": {
-                "async": "2.6.2",
-                "async-eventemitter": "0.2.4",
-                "ethereumjs-account": "2.0.5",
-                "ethereumjs-block": "2.2.2",
-                "ethereumjs-common": "1.5.0",
-                "ethereumjs-util": "6.2.1",
-                "fake-merkle-patricia-tree": "1.0.1",
-                "functional-red-black-tree": "1.0.1",
-                "merkle-patricia-tree": "2.3.2",
-                "rustbn.js": "0.2.0",
-                "safe-buffer": "5.1.2"
+                "async": "^2.1.2",
+                "async-eventemitter": "^0.2.2",
+                "ethereumjs-account": "^2.0.3",
+                "ethereumjs-block": "~2.2.0",
+                "ethereumjs-common": "^1.1.0",
+                "ethereumjs-util": "^6.0.0",
+                "fake-merkle-patricia-tree": "^1.0.1",
+                "functional-red-black-tree": "^1.0.1",
+                "merkle-patricia-tree": "^2.3.2",
+                "rustbn.js": "~0.2.0",
+                "safe-buffer": "^5.1.1"
               },
               "dependencies": {
                 "ethereumjs-block": {
@@ -5340,11 +5378,11 @@
                   "integrity": "sha512-2p49ifhek3h2zeg/+da6XpdFR3GlqY3BIEiqxGF8j9aSRIgkb7M1Ky+yULBKJOu8PAZxfhsYA+HxUk2aCQp3vg==",
                   "dev": true,
                   "requires": {
-                    "async": "2.6.2",
-                    "ethereumjs-common": "1.5.0",
-                    "ethereumjs-tx": "2.1.2",
-                    "ethereumjs-util": "5.2.1",
-                    "merkle-patricia-tree": "2.3.2"
+                    "async": "^2.0.1",
+                    "ethereumjs-common": "^1.5.0",
+                    "ethereumjs-tx": "^2.1.1",
+                    "ethereumjs-util": "^5.0.0",
+                    "merkle-patricia-tree": "^2.1.2"
                   },
                   "dependencies": {
                     "ethereumjs-util": {
@@ -5353,13 +5391,13 @@
                       "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
                       "dev": true,
                       "requires": {
-                        "bn.js": "4.11.9",
-                        "create-hash": "1.2.0",
-                        "elliptic": "6.5.3",
-                        "ethereum-cryptography": "0.1.3",
-                        "ethjs-util": "0.1.6",
-                        "rlp": "2.2.6",
-                        "safe-buffer": "5.1.2"
+                        "bn.js": "^4.11.0",
+                        "create-hash": "^1.1.2",
+                        "elliptic": "^6.5.2",
+                        "ethereum-cryptography": "^0.1.3",
+                        "ethjs-util": "^0.1.3",
+                        "rlp": "^2.0.0",
+                        "safe-buffer": "^5.1.1"
                       }
                     }
                   }
@@ -5370,8 +5408,8 @@
                   "integrity": "sha512-zZEK1onCeiORb0wyCXUvg94Ve5It/K6GD1K+26KfFKodiBiS6d9lfCXlUKGBBdQ+bv7Day+JK0tj1K+BeNFRAw==",
                   "dev": true,
                   "requires": {
-                    "ethereumjs-common": "1.5.0",
-                    "ethereumjs-util": "6.2.1"
+                    "ethereumjs-common": "^1.5.0",
+                    "ethereumjs-util": "^6.0.0"
                   }
                 },
                 "ethereumjs-util": {
@@ -5380,13 +5418,13 @@
                   "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
                   "dev": true,
                   "requires": {
-                    "@types/bn.js": "4.11.6",
-                    "bn.js": "4.11.9",
-                    "create-hash": "1.2.0",
-                    "elliptic": "6.5.3",
-                    "ethereum-cryptography": "0.1.3",
+                    "@types/bn.js": "^4.11.3",
+                    "bn.js": "^4.11.0",
+                    "create-hash": "^1.1.2",
+                    "elliptic": "^6.5.2",
+                    "ethereum-cryptography": "^0.1.3",
                     "ethjs-util": "0.1.6",
-                    "rlp": "2.2.6"
+                    "rlp": "^2.2.3"
                   }
                 }
               }
@@ -5409,7 +5447,7 @@
               "integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
               "dev": true,
               "requires": {
-                "errno": "0.1.8"
+                "errno": "~0.1.1"
               }
             },
             "level-iterator-stream": {
@@ -5418,10 +5456,10 @@
               "integrity": "sha1-5Dt4sagUPm+pek9IXrjqUwNS8u0=",
               "dev": true,
               "requires": {
-                "inherits": "2.0.4",
-                "level-errors": "1.0.5",
-                "readable-stream": "1.1.14",
-                "xtend": "4.0.2"
+                "inherits": "^2.0.1",
+                "level-errors": "^1.0.3",
+                "readable-stream": "^1.0.33",
+                "xtend": "^4.0.0"
               },
               "dependencies": {
                 "readable-stream": {
@@ -5430,10 +5468,10 @@
                   "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
                   "dev": true,
                   "requires": {
-                    "core-util-is": "1.0.2",
-                    "inherits": "2.0.4",
+                    "core-util-is": "~1.0.0",
+                    "inherits": "~2.0.1",
                     "isarray": "0.0.1",
-                    "string_decoder": "0.10.31"
+                    "string_decoder": "~0.10.x"
                   }
                 }
               }
@@ -5444,8 +5482,8 @@
               "integrity": "sha1-Ny5RIXeSSgBCSwtDrvK7QkltIos=",
               "dev": true,
               "requires": {
-                "readable-stream": "1.0.34",
-                "xtend": "2.1.2"
+                "readable-stream": "~1.0.15",
+                "xtend": "~2.1.1"
               },
               "dependencies": {
                 "readable-stream": {
@@ -5454,10 +5492,10 @@
                   "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                   "dev": true,
                   "requires": {
-                    "core-util-is": "1.0.2",
-                    "inherits": "2.0.4",
+                    "core-util-is": "~1.0.0",
+                    "inherits": "~2.0.1",
                     "isarray": "0.0.1",
-                    "string_decoder": "0.10.31"
+                    "string_decoder": "~0.10.x"
                   }
                 },
                 "xtend": {
@@ -5466,7 +5504,7 @@
                   "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
                   "dev": true,
                   "requires": {
-                    "object-keys": "0.4.0"
+                    "object-keys": "~0.4.0"
                   }
                 }
               }
@@ -5477,13 +5515,13 @@
               "integrity": "sha512-VVGHfKIlmw8w1XqpGOAGwq6sZm2WwWLmlDcULkKWQXEA5EopA8OBNJ2Ck2v6bdk8HeEZSbCSEgzXadyQFm76sQ==",
               "dev": true,
               "requires": {
-                "deferred-leveldown": "1.2.2",
-                "level-codec": "7.0.1",
-                "level-errors": "1.0.5",
-                "level-iterator-stream": "1.3.1",
-                "prr": "1.0.1",
-                "semver": "5.4.1",
-                "xtend": "4.0.2"
+                "deferred-leveldown": "~1.2.1",
+                "level-codec": "~7.0.0",
+                "level-errors": "~1.0.3",
+                "level-iterator-stream": "~1.3.0",
+                "prr": "~1.0.1",
+                "semver": "~5.4.1",
+                "xtend": "~4.0.0"
               }
             },
             "ltgt": {
@@ -5498,12 +5536,12 @@
               "integrity": "sha1-tOThkhdGZP+65BNhqlAPMRnv4hU=",
               "dev": true,
               "requires": {
-                "abstract-leveldown": "2.7.2",
-                "functional-red-black-tree": "1.0.1",
-                "immediate": "3.2.3",
-                "inherits": "2.0.4",
-                "ltgt": "2.2.1",
-                "safe-buffer": "5.1.2"
+                "abstract-leveldown": "~2.7.1",
+                "functional-red-black-tree": "^1.0.1",
+                "immediate": "^3.2.3",
+                "inherits": "~2.0.1",
+                "ltgt": "~2.2.0",
+                "safe-buffer": "~5.1.1"
               },
               "dependencies": {
                 "abstract-leveldown": {
@@ -5512,7 +5550,7 @@
                   "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
                   "dev": true,
                   "requires": {
-                    "xtend": "4.0.2"
+                    "xtend": "~4.0.0"
                   }
                 }
               }
@@ -5523,14 +5561,14 @@
               "integrity": "sha512-81PW5m8oz/pz3GvsAwbauj7Y00rqm81Tzad77tHBwU7pIAtN+TJnMSOJhxBKflSVYhptMMb9RskhqHqrSm1V+g==",
               "dev": true,
               "requires": {
-                "async": "1.5.2",
-                "ethereumjs-util": "5.2.1",
+                "async": "^1.4.2",
+                "ethereumjs-util": "^5.0.0",
                 "level-ws": "0.0.0",
-                "levelup": "1.3.9",
-                "memdown": "1.4.1",
-                "readable-stream": "2.3.7",
-                "rlp": "2.2.6",
-                "semaphore": "1.1.0"
+                "levelup": "^1.2.1",
+                "memdown": "^1.0.0",
+                "readable-stream": "^2.0.0",
+                "rlp": "^2.0.0",
+                "semaphore": ">=1.0.1"
               },
               "dependencies": {
                 "async": {
@@ -5574,12 +5612,12 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "bn.js": "4.11.9",
-            "elliptic": "6.5.3",
-            "nano-json-stream-parser": "0.1.2",
-            "servify": "0.1.12",
-            "ws": "3.3.3",
-            "xhr-request-promise": "0.1.3"
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "nano-json-stream-parser": "^0.1.2",
+            "servify": "^0.1.12",
+            "ws": "^3.0.0",
+            "xhr-request-promise": "^0.1.2"
           }
         },
         "eth-query": {
@@ -5588,8 +5626,8 @@
           "integrity": "sha1-1nQdkAAQa1FRDHLbktY2VFam2l4=",
           "dev": true,
           "requires": {
-            "json-rpc-random-id": "1.0.1",
-            "xtend": "4.0.2"
+            "json-rpc-random-id": "^1.0.0",
+            "xtend": "^4.0.1"
           }
         },
         "eth-sig-util": {
@@ -5598,12 +5636,12 @@
           "integrity": "sha512-4eFkMOhpGbTxBQ3AMzVf0haUX2uTur7DpWiHzWyTURa28BVJJtOkcb9Ok5TV0YvEPG61DODPW7ZUATbJTslioQ==",
           "dev": true,
           "requires": {
-            "buffer": "5.7.1",
-            "elliptic": "6.5.3",
+            "buffer": "^5.2.1",
+            "elliptic": "^6.4.0",
             "ethereumjs-abi": "0.6.5",
-            "ethereumjs-util": "5.2.1",
-            "tweetnacl": "1.0.3",
-            "tweetnacl-util": "0.15.1"
+            "ethereumjs-util": "^5.1.1",
+            "tweetnacl": "^1.0.0",
+            "tweetnacl-util": "^0.15.0"
           },
           "dependencies": {
             "ethereumjs-abi": {
@@ -5612,8 +5650,8 @@
               "integrity": "sha1-WmN+8Wq0NHP6cqKa2QhxQFs/UkE=",
               "dev": true,
               "requires": {
-                "bn.js": "4.11.9",
-                "ethereumjs-util": "4.5.1"
+                "bn.js": "^4.10.0",
+                "ethereumjs-util": "^4.3.0"
               },
               "dependencies": {
                 "ethereumjs-util": {
@@ -5622,11 +5660,11 @@
                   "integrity": "sha512-WrckOZ7uBnei4+AKimpuF1B3Fv25OmoRgmYCpGsP7u8PFxXAmAgiJSYT2kRWnt6fVIlKaQlZvuwXp7PIrmn3/w==",
                   "dev": true,
                   "requires": {
-                    "bn.js": "4.11.9",
-                    "create-hash": "1.2.0",
-                    "elliptic": "6.5.3",
-                    "ethereum-cryptography": "0.1.3",
-                    "rlp": "2.2.6"
+                    "bn.js": "^4.8.0",
+                    "create-hash": "^1.1.2",
+                    "elliptic": "^6.5.2",
+                    "ethereum-cryptography": "^0.1.3",
+                    "rlp": "^2.0.0"
                   }
                 }
               }
@@ -5637,13 +5675,13 @@
               "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
               "dev": true,
               "requires": {
-                "bn.js": "4.11.9",
-                "create-hash": "1.2.0",
-                "elliptic": "6.5.3",
-                "ethereum-cryptography": "0.1.3",
-                "ethjs-util": "0.1.6",
-                "rlp": "2.2.6",
-                "safe-buffer": "5.2.1"
+                "bn.js": "^4.11.0",
+                "create-hash": "^1.1.2",
+                "elliptic": "^6.5.2",
+                "ethereum-cryptography": "^0.1.3",
+                "ethjs-util": "^0.1.3",
+                "rlp": "^2.0.0",
+                "safe-buffer": "^5.1.1"
               }
             }
           }
@@ -5654,16 +5692,16 @@
           "integrity": "sha512-NtlDnaVZah146Rm8HMRUNMgIwG/ED4jiqk0TME9zFheMl1jOp6jL1m0NKGjJwehXQ6ZKCPr16MTr+qspKpEXNg==",
           "dev": true,
           "requires": {
-            "async": "2.6.2",
-            "clone": "2.1.2",
-            "concat-stream": "1.6.2",
-            "end-of-stream": "1.4.4",
-            "eth-query": "2.1.2",
-            "ethereumjs-block": "1.7.1",
-            "ethereumjs-tx": "1.3.7",
-            "ethereumjs-util": "5.2.1",
-            "ethereumjs-vm": "2.6.0",
-            "through2": "2.0.5"
+            "async": "^2.1.2",
+            "clone": "^2.0.0",
+            "concat-stream": "^1.5.1",
+            "end-of-stream": "^1.1.0",
+            "eth-query": "^2.0.2",
+            "ethereumjs-block": "^1.4.1",
+            "ethereumjs-tx": "^1.1.1",
+            "ethereumjs-util": "^5.0.1",
+            "ethereumjs-vm": "^2.6.0",
+            "through2": "^2.0.3"
           },
           "dependencies": {
             "abstract-leveldown": {
@@ -5672,7 +5710,7 @@
               "integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
               "dev": true,
               "requires": {
-                "xtend": "4.0.2"
+                "xtend": "~4.0.0"
               }
             },
             "deferred-leveldown": {
@@ -5681,7 +5719,7 @@
               "integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
               "dev": true,
               "requires": {
-                "abstract-leveldown": "2.6.3"
+                "abstract-leveldown": "~2.6.0"
               }
             },
             "ethereumjs-account": {
@@ -5690,9 +5728,9 @@
               "integrity": "sha512-bgDojnXGjhMwo6eXQC0bY6UK2liSFUSMwwylOmQvZbSl/D7NXQ3+vrGO46ZeOgjGfxXmgIeVNDIiHw7fNZM4VA==",
               "dev": true,
               "requires": {
-                "ethereumjs-util": "5.2.1",
-                "rlp": "2.2.6",
-                "safe-buffer": "5.1.2"
+                "ethereumjs-util": "^5.0.0",
+                "rlp": "^2.0.0",
+                "safe-buffer": "^5.1.1"
               }
             },
             "ethereumjs-block": {
@@ -5701,11 +5739,11 @@
               "integrity": "sha512-B+sSdtqm78fmKkBq78/QLKJbu/4Ts4P2KFISdgcuZUPDm9x+N7qgBPIIFUGbaakQh8bzuquiRVbdmvPKqbILRg==",
               "dev": true,
               "requires": {
-                "async": "2.6.2",
+                "async": "^2.0.1",
                 "ethereum-common": "0.2.0",
-                "ethereumjs-tx": "1.3.7",
-                "ethereumjs-util": "5.2.1",
-                "merkle-patricia-tree": "2.3.2"
+                "ethereumjs-tx": "^1.2.2",
+                "ethereumjs-util": "^5.0.0",
+                "merkle-patricia-tree": "^2.1.2"
               },
               "dependencies": {
                 "ethereum-common": {
@@ -5722,8 +5760,8 @@
               "integrity": "sha512-wvLMxzt1RPhAQ9Yi3/HKZTn0FZYpnsmQdbKYfUUpi4j1SEIcbkd9tndVjcPrufY3V7j2IebOpC00Zp2P/Ay2kA==",
               "dev": true,
               "requires": {
-                "ethereum-common": "0.0.18",
-                "ethereumjs-util": "5.2.1"
+                "ethereum-common": "^0.0.18",
+                "ethereumjs-util": "^5.0.0"
               }
             },
             "ethereumjs-util": {
@@ -5732,13 +5770,13 @@
               "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
               "dev": true,
               "requires": {
-                "bn.js": "4.11.9",
-                "create-hash": "1.2.0",
-                "elliptic": "6.5.3",
-                "ethereum-cryptography": "0.1.3",
-                "ethjs-util": "0.1.6",
-                "rlp": "2.2.6",
-                "safe-buffer": "5.1.2"
+                "bn.js": "^4.11.0",
+                "create-hash": "^1.1.2",
+                "elliptic": "^6.5.2",
+                "ethereum-cryptography": "^0.1.3",
+                "ethjs-util": "^0.1.3",
+                "rlp": "^2.0.0",
+                "safe-buffer": "^5.1.1"
               }
             },
             "ethereumjs-vm": {
@@ -5747,17 +5785,17 @@
               "integrity": "sha512-r/XIUik/ynGbxS3y+mvGnbOKnuLo40V5Mj1J25+HEO63aWYREIqvWeRO/hnROlMBE5WoniQmPmhiaN0ctiHaXw==",
               "dev": true,
               "requires": {
-                "async": "2.6.2",
-                "async-eventemitter": "0.2.4",
-                "ethereumjs-account": "2.0.5",
-                "ethereumjs-block": "2.2.2",
-                "ethereumjs-common": "1.5.0",
-                "ethereumjs-util": "6.2.1",
-                "fake-merkle-patricia-tree": "1.0.1",
-                "functional-red-black-tree": "1.0.1",
-                "merkle-patricia-tree": "2.3.2",
-                "rustbn.js": "0.2.0",
-                "safe-buffer": "5.1.2"
+                "async": "^2.1.2",
+                "async-eventemitter": "^0.2.2",
+                "ethereumjs-account": "^2.0.3",
+                "ethereumjs-block": "~2.2.0",
+                "ethereumjs-common": "^1.1.0",
+                "ethereumjs-util": "^6.0.0",
+                "fake-merkle-patricia-tree": "^1.0.1",
+                "functional-red-black-tree": "^1.0.1",
+                "merkle-patricia-tree": "^2.3.2",
+                "rustbn.js": "~0.2.0",
+                "safe-buffer": "^5.1.1"
               },
               "dependencies": {
                 "ethereumjs-block": {
@@ -5766,11 +5804,11 @@
                   "integrity": "sha512-2p49ifhek3h2zeg/+da6XpdFR3GlqY3BIEiqxGF8j9aSRIgkb7M1Ky+yULBKJOu8PAZxfhsYA+HxUk2aCQp3vg==",
                   "dev": true,
                   "requires": {
-                    "async": "2.6.2",
-                    "ethereumjs-common": "1.5.0",
-                    "ethereumjs-tx": "2.1.2",
-                    "ethereumjs-util": "5.2.1",
-                    "merkle-patricia-tree": "2.3.2"
+                    "async": "^2.0.1",
+                    "ethereumjs-common": "^1.5.0",
+                    "ethereumjs-tx": "^2.1.1",
+                    "ethereumjs-util": "^5.0.0",
+                    "merkle-patricia-tree": "^2.1.2"
                   },
                   "dependencies": {
                     "ethereumjs-util": {
@@ -5779,13 +5817,13 @@
                       "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
                       "dev": true,
                       "requires": {
-                        "bn.js": "4.11.9",
-                        "create-hash": "1.2.0",
-                        "elliptic": "6.5.3",
-                        "ethereum-cryptography": "0.1.3",
-                        "ethjs-util": "0.1.6",
-                        "rlp": "2.2.6",
-                        "safe-buffer": "5.1.2"
+                        "bn.js": "^4.11.0",
+                        "create-hash": "^1.1.2",
+                        "elliptic": "^6.5.2",
+                        "ethereum-cryptography": "^0.1.3",
+                        "ethjs-util": "^0.1.3",
+                        "rlp": "^2.0.0",
+                        "safe-buffer": "^5.1.1"
                       }
                     }
                   }
@@ -5796,8 +5834,8 @@
                   "integrity": "sha512-zZEK1onCeiORb0wyCXUvg94Ve5It/K6GD1K+26KfFKodiBiS6d9lfCXlUKGBBdQ+bv7Day+JK0tj1K+BeNFRAw==",
                   "dev": true,
                   "requires": {
-                    "ethereumjs-common": "1.5.0",
-                    "ethereumjs-util": "6.2.1"
+                    "ethereumjs-common": "^1.5.0",
+                    "ethereumjs-util": "^6.0.0"
                   }
                 },
                 "ethereumjs-util": {
@@ -5806,13 +5844,13 @@
                   "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
                   "dev": true,
                   "requires": {
-                    "@types/bn.js": "4.11.6",
-                    "bn.js": "4.11.9",
-                    "create-hash": "1.2.0",
-                    "elliptic": "6.5.3",
-                    "ethereum-cryptography": "0.1.3",
+                    "@types/bn.js": "^4.11.3",
+                    "bn.js": "^4.11.0",
+                    "create-hash": "^1.1.2",
+                    "elliptic": "^6.5.2",
+                    "ethereum-cryptography": "^0.1.3",
                     "ethjs-util": "0.1.6",
-                    "rlp": "2.2.6"
+                    "rlp": "^2.2.3"
                   }
                 }
               }
@@ -5835,7 +5873,7 @@
               "integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
               "dev": true,
               "requires": {
-                "errno": "0.1.8"
+                "errno": "~0.1.1"
               }
             },
             "level-iterator-stream": {
@@ -5844,10 +5882,10 @@
               "integrity": "sha1-5Dt4sagUPm+pek9IXrjqUwNS8u0=",
               "dev": true,
               "requires": {
-                "inherits": "2.0.4",
-                "level-errors": "1.0.5",
-                "readable-stream": "1.1.14",
-                "xtend": "4.0.2"
+                "inherits": "^2.0.1",
+                "level-errors": "^1.0.3",
+                "readable-stream": "^1.0.33",
+                "xtend": "^4.0.0"
               },
               "dependencies": {
                 "readable-stream": {
@@ -5856,10 +5894,10 @@
                   "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
                   "dev": true,
                   "requires": {
-                    "core-util-is": "1.0.2",
-                    "inherits": "2.0.4",
+                    "core-util-is": "~1.0.0",
+                    "inherits": "~2.0.1",
                     "isarray": "0.0.1",
-                    "string_decoder": "0.10.31"
+                    "string_decoder": "~0.10.x"
                   }
                 }
               }
@@ -5870,8 +5908,8 @@
               "integrity": "sha1-Ny5RIXeSSgBCSwtDrvK7QkltIos=",
               "dev": true,
               "requires": {
-                "readable-stream": "1.0.34",
-                "xtend": "2.1.2"
+                "readable-stream": "~1.0.15",
+                "xtend": "~2.1.1"
               },
               "dependencies": {
                 "readable-stream": {
@@ -5880,10 +5918,10 @@
                   "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                   "dev": true,
                   "requires": {
-                    "core-util-is": "1.0.2",
-                    "inherits": "2.0.4",
+                    "core-util-is": "~1.0.0",
+                    "inherits": "~2.0.1",
                     "isarray": "0.0.1",
-                    "string_decoder": "0.10.31"
+                    "string_decoder": "~0.10.x"
                   }
                 },
                 "xtend": {
@@ -5892,7 +5930,7 @@
                   "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
                   "dev": true,
                   "requires": {
-                    "object-keys": "0.4.0"
+                    "object-keys": "~0.4.0"
                   }
                 }
               }
@@ -5903,13 +5941,13 @@
               "integrity": "sha512-VVGHfKIlmw8w1XqpGOAGwq6sZm2WwWLmlDcULkKWQXEA5EopA8OBNJ2Ck2v6bdk8HeEZSbCSEgzXadyQFm76sQ==",
               "dev": true,
               "requires": {
-                "deferred-leveldown": "1.2.2",
-                "level-codec": "7.0.1",
-                "level-errors": "1.0.5",
-                "level-iterator-stream": "1.3.1",
-                "prr": "1.0.1",
-                "semver": "5.4.1",
-                "xtend": "4.0.2"
+                "deferred-leveldown": "~1.2.1",
+                "level-codec": "~7.0.0",
+                "level-errors": "~1.0.3",
+                "level-iterator-stream": "~1.3.0",
+                "prr": "~1.0.1",
+                "semver": "~5.4.1",
+                "xtend": "~4.0.0"
               }
             },
             "ltgt": {
@@ -5924,12 +5962,12 @@
               "integrity": "sha1-tOThkhdGZP+65BNhqlAPMRnv4hU=",
               "dev": true,
               "requires": {
-                "abstract-leveldown": "2.7.2",
-                "functional-red-black-tree": "1.0.1",
-                "immediate": "3.2.3",
-                "inherits": "2.0.4",
-                "ltgt": "2.2.1",
-                "safe-buffer": "5.1.2"
+                "abstract-leveldown": "~2.7.1",
+                "functional-red-black-tree": "^1.0.1",
+                "immediate": "^3.2.3",
+                "inherits": "~2.0.1",
+                "ltgt": "~2.2.0",
+                "safe-buffer": "~5.1.1"
               },
               "dependencies": {
                 "abstract-leveldown": {
@@ -5938,7 +5976,7 @@
                   "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
                   "dev": true,
                   "requires": {
-                    "xtend": "4.0.2"
+                    "xtend": "~4.0.0"
                   }
                 }
               }
@@ -5949,14 +5987,14 @@
               "integrity": "sha512-81PW5m8oz/pz3GvsAwbauj7Y00rqm81Tzad77tHBwU7pIAtN+TJnMSOJhxBKflSVYhptMMb9RskhqHqrSm1V+g==",
               "dev": true,
               "requires": {
-                "async": "1.5.2",
-                "ethereumjs-util": "5.2.1",
+                "async": "^1.4.2",
+                "ethereumjs-util": "^5.0.0",
                 "level-ws": "0.0.0",
-                "levelup": "1.3.9",
-                "memdown": "1.4.1",
-                "readable-stream": "2.3.7",
-                "rlp": "2.2.6",
-                "semaphore": "1.1.0"
+                "levelup": "^1.2.1",
+                "memdown": "^1.0.0",
+                "readable-stream": "^2.0.0",
+                "rlp": "^2.0.0",
+                "semaphore": ">=1.0.1"
               },
               "dependencies": {
                 "async": {
@@ -5999,10 +6037,10 @@
           "integrity": "sha512-/MSbf/r2/Ld8o0l15AymjOTlPqpN8Cr4ByUEA9GtR4x0yAh3TdtDzEg29zMjXCNPI7u6E5fOQdj/Cf9Tc7oVNw==",
           "dev": true,
           "requires": {
-            "async": "2.6.2",
-            "buffer-xor": "2.0.2",
-            "ethereumjs-util": "7.0.7",
-            "miller-rabin": "4.0.1"
+            "async": "^2.1.2",
+            "buffer-xor": "^2.0.1",
+            "ethereumjs-util": "^7.0.2",
+            "miller-rabin": "^4.0.0"
           },
           "dependencies": {
             "bn.js": {
@@ -6017,7 +6055,7 @@
               "integrity": "sha512-eHslX0bin3GB+Lx2p7lEYRShRewuNZL3fUl4qlVJGGiwoPGftmt8JQgk2Y9Ji5/01TnVDo33E5b5O3vUB1HdqQ==",
               "dev": true,
               "requires": {
-                "safe-buffer": "5.2.1"
+                "safe-buffer": "^5.1.1"
               }
             },
             "ethereumjs-util": {
@@ -6026,12 +6064,12 @@
               "integrity": "sha512-vU5rtZBlZsgkTw3o6PDKyB8li2EgLavnAbsKcfsH2YhHH1Le+PP8vEiMnAnvgc1B6uMoaM5GDCrVztBw0Q5K9g==",
               "dev": true,
               "requires": {
-                "@types/bn.js": "4.11.6",
-                "bn.js": "5.1.3",
-                "create-hash": "1.2.0",
-                "ethereum-cryptography": "0.1.3",
+                "@types/bn.js": "^4.11.3",
+                "bn.js": "^5.1.2",
+                "create-hash": "^1.1.2",
+                "ethereum-cryptography": "^0.1.3",
                 "ethjs-util": "0.1.6",
-                "rlp": "2.2.6"
+                "rlp": "^2.2.4"
               }
             }
           }
@@ -6041,15 +6079,17 @@
           "resolved": "https://registry.npmjs.org/ethereum-bloom-filters/-/ethereum-bloom-filters-1.0.7.tgz",
           "integrity": "sha512-cDcJJSJ9GMAcURiAWO3DxIEhTL/uWqlQnvgKpuYQzYPrt/izuGU+1ntQmHt0IRq6ADoSYHFnB+aCEFIldjhkMQ==",
           "dev": true,
+          "optional": true,
           "requires": {
-            "js-sha3": "0.8.0"
+            "js-sha3": "^0.8.0"
           },
           "dependencies": {
             "js-sha3": {
               "version": "0.8.0",
               "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
               "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -6065,21 +6105,21 @@
           "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
           "dev": true,
           "requires": {
-            "@types/pbkdf2": "3.1.0",
-            "@types/secp256k1": "4.0.1",
-            "blakejs": "1.1.0",
-            "browserify-aes": "1.2.0",
-            "bs58check": "2.1.2",
-            "create-hash": "1.2.0",
-            "create-hmac": "1.1.7",
-            "hash.js": "1.1.7",
-            "keccak": "3.0.1",
-            "pbkdf2": "3.1.1",
-            "randombytes": "2.1.0",
-            "safe-buffer": "5.2.1",
-            "scrypt-js": "3.0.1",
-            "secp256k1": "4.0.2",
-            "setimmediate": "1.0.5"
+            "@types/pbkdf2": "^3.0.0",
+            "@types/secp256k1": "^4.0.1",
+            "blakejs": "^1.1.0",
+            "browserify-aes": "^1.2.0",
+            "bs58check": "^2.1.2",
+            "create-hash": "^1.2.0",
+            "create-hmac": "^1.1.7",
+            "hash.js": "^1.1.7",
+            "keccak": "^3.0.0",
+            "pbkdf2": "^3.0.17",
+            "randombytes": "^2.1.0",
+            "safe-buffer": "^5.1.2",
+            "scrypt-js": "^3.0.0",
+            "secp256k1": "^4.0.1",
+            "setimmediate": "^1.0.5"
           }
         },
         "ethereumjs-abi": {
@@ -6088,8 +6128,8 @@
           "integrity": "sha512-Tx0r/iXI6r+lRsdvkFDlut0N08jWMnKRZ6Gkq+Nmw75lZe4e6o3EkSnkaBP5NF6+m5PTGAr9JP43N3LyeoglsA==",
           "dev": true,
           "requires": {
-            "bn.js": "4.11.9",
-            "ethereumjs-util": "6.2.1"
+            "bn.js": "^4.11.8",
+            "ethereumjs-util": "^6.0.0"
           }
         },
         "ethereumjs-account": {
@@ -6098,9 +6138,9 @@
           "integrity": "sha512-WP6BdscjiiPkQfF9PVfMcwx/rDvfZTjFKY0Uwc09zSQr9JfIVH87dYIJu0gNhBhpmovV4yq295fdllS925fnBA==",
           "dev": true,
           "requires": {
-            "ethereumjs-util": "6.2.1",
-            "rlp": "2.2.6",
-            "safe-buffer": "5.2.1"
+            "ethereumjs-util": "^6.0.0",
+            "rlp": "^2.2.1",
+            "safe-buffer": "^5.1.1"
           }
         },
         "ethereumjs-block": {
@@ -6109,11 +6149,11 @@
           "integrity": "sha512-2p49ifhek3h2zeg/+da6XpdFR3GlqY3BIEiqxGF8j9aSRIgkb7M1Ky+yULBKJOu8PAZxfhsYA+HxUk2aCQp3vg==",
           "dev": true,
           "requires": {
-            "async": "2.6.2",
-            "ethereumjs-common": "1.5.0",
-            "ethereumjs-tx": "2.1.2",
-            "ethereumjs-util": "5.2.1",
-            "merkle-patricia-tree": "2.3.2"
+            "async": "^2.0.1",
+            "ethereumjs-common": "^1.5.0",
+            "ethereumjs-tx": "^2.1.1",
+            "ethereumjs-util": "^5.0.0",
+            "merkle-patricia-tree": "^2.1.2"
           },
           "dependencies": {
             "abstract-leveldown": {
@@ -6122,7 +6162,7 @@
               "integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
               "dev": true,
               "requires": {
-                "xtend": "4.0.2"
+                "xtend": "~4.0.0"
               }
             },
             "deferred-leveldown": {
@@ -6131,7 +6171,7 @@
               "integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
               "dev": true,
               "requires": {
-                "abstract-leveldown": "2.6.3"
+                "abstract-leveldown": "~2.6.0"
               }
             },
             "ethereumjs-util": {
@@ -6140,13 +6180,13 @@
               "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
               "dev": true,
               "requires": {
-                "bn.js": "4.11.9",
-                "create-hash": "1.2.0",
-                "elliptic": "6.5.3",
-                "ethereum-cryptography": "0.1.3",
-                "ethjs-util": "0.1.6",
-                "rlp": "2.2.6",
-                "safe-buffer": "5.1.2"
+                "bn.js": "^4.11.0",
+                "create-hash": "^1.1.2",
+                "elliptic": "^6.5.2",
+                "ethereum-cryptography": "^0.1.3",
+                "ethjs-util": "^0.1.3",
+                "rlp": "^2.0.0",
+                "safe-buffer": "^5.1.1"
               }
             },
             "isarray": {
@@ -6167,7 +6207,7 @@
               "integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
               "dev": true,
               "requires": {
-                "errno": "0.1.8"
+                "errno": "~0.1.1"
               }
             },
             "level-iterator-stream": {
@@ -6176,10 +6216,10 @@
               "integrity": "sha1-5Dt4sagUPm+pek9IXrjqUwNS8u0=",
               "dev": true,
               "requires": {
-                "inherits": "2.0.4",
-                "level-errors": "1.0.5",
-                "readable-stream": "1.1.14",
-                "xtend": "4.0.2"
+                "inherits": "^2.0.1",
+                "level-errors": "^1.0.3",
+                "readable-stream": "^1.0.33",
+                "xtend": "^4.0.0"
               },
               "dependencies": {
                 "readable-stream": {
@@ -6188,10 +6228,10 @@
                   "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
                   "dev": true,
                   "requires": {
-                    "core-util-is": "1.0.2",
-                    "inherits": "2.0.4",
+                    "core-util-is": "~1.0.0",
+                    "inherits": "~2.0.1",
                     "isarray": "0.0.1",
-                    "string_decoder": "0.10.31"
+                    "string_decoder": "~0.10.x"
                   }
                 }
               }
@@ -6202,8 +6242,8 @@
               "integrity": "sha1-Ny5RIXeSSgBCSwtDrvK7QkltIos=",
               "dev": true,
               "requires": {
-                "readable-stream": "1.0.34",
-                "xtend": "2.1.2"
+                "readable-stream": "~1.0.15",
+                "xtend": "~2.1.1"
               },
               "dependencies": {
                 "readable-stream": {
@@ -6212,10 +6252,10 @@
                   "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                   "dev": true,
                   "requires": {
-                    "core-util-is": "1.0.2",
-                    "inherits": "2.0.4",
+                    "core-util-is": "~1.0.0",
+                    "inherits": "~2.0.1",
                     "isarray": "0.0.1",
-                    "string_decoder": "0.10.31"
+                    "string_decoder": "~0.10.x"
                   }
                 },
                 "xtend": {
@@ -6224,7 +6264,7 @@
                   "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
                   "dev": true,
                   "requires": {
-                    "object-keys": "0.4.0"
+                    "object-keys": "~0.4.0"
                   }
                 }
               }
@@ -6235,13 +6275,13 @@
               "integrity": "sha512-VVGHfKIlmw8w1XqpGOAGwq6sZm2WwWLmlDcULkKWQXEA5EopA8OBNJ2Ck2v6bdk8HeEZSbCSEgzXadyQFm76sQ==",
               "dev": true,
               "requires": {
-                "deferred-leveldown": "1.2.2",
-                "level-codec": "7.0.1",
-                "level-errors": "1.0.5",
-                "level-iterator-stream": "1.3.1",
-                "prr": "1.0.1",
-                "semver": "5.4.1",
-                "xtend": "4.0.2"
+                "deferred-leveldown": "~1.2.1",
+                "level-codec": "~7.0.0",
+                "level-errors": "~1.0.3",
+                "level-iterator-stream": "~1.3.0",
+                "prr": "~1.0.1",
+                "semver": "~5.4.1",
+                "xtend": "~4.0.0"
               }
             },
             "ltgt": {
@@ -6256,12 +6296,12 @@
               "integrity": "sha1-tOThkhdGZP+65BNhqlAPMRnv4hU=",
               "dev": true,
               "requires": {
-                "abstract-leveldown": "2.7.2",
-                "functional-red-black-tree": "1.0.1",
-                "immediate": "3.2.3",
-                "inherits": "2.0.4",
-                "ltgt": "2.2.1",
-                "safe-buffer": "5.1.2"
+                "abstract-leveldown": "~2.7.1",
+                "functional-red-black-tree": "^1.0.1",
+                "immediate": "^3.2.3",
+                "inherits": "~2.0.1",
+                "ltgt": "~2.2.0",
+                "safe-buffer": "~5.1.1"
               },
               "dependencies": {
                 "abstract-leveldown": {
@@ -6270,7 +6310,7 @@
                   "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
                   "dev": true,
                   "requires": {
-                    "xtend": "4.0.2"
+                    "xtend": "~4.0.0"
                   }
                 }
               }
@@ -6281,14 +6321,14 @@
               "integrity": "sha512-81PW5m8oz/pz3GvsAwbauj7Y00rqm81Tzad77tHBwU7pIAtN+TJnMSOJhxBKflSVYhptMMb9RskhqHqrSm1V+g==",
               "dev": true,
               "requires": {
-                "async": "1.5.2",
-                "ethereumjs-util": "5.2.1",
+                "async": "^1.4.2",
+                "ethereumjs-util": "^5.0.0",
                 "level-ws": "0.0.0",
-                "levelup": "1.3.9",
-                "memdown": "1.4.1",
-                "readable-stream": "2.3.7",
-                "rlp": "2.2.6",
-                "semaphore": "1.1.0"
+                "levelup": "^1.2.1",
+                "memdown": "^1.0.0",
+                "readable-stream": "^2.0.0",
+                "rlp": "^2.0.0",
+                "semaphore": ">=1.0.1"
               },
               "dependencies": {
                 "async": {
@@ -6331,16 +6371,16 @@
           "integrity": "sha512-zCxaRMUOzzjvX78DTGiKjA+4h2/sF0OYL1QuPux0DHpyq8XiNoF5GYHtb++GUxVlMsMfZV7AVyzbtgcRdIcEPQ==",
           "dev": true,
           "requires": {
-            "async": "2.6.2",
-            "ethashjs": "0.0.8",
-            "ethereumjs-block": "2.2.2",
-            "ethereumjs-common": "1.5.0",
-            "ethereumjs-util": "6.2.1",
-            "flow-stoplight": "1.0.0",
-            "level-mem": "3.0.1",
-            "lru-cache": "5.1.1",
-            "rlp": "2.2.6",
-            "semaphore": "1.1.0"
+            "async": "^2.6.1",
+            "ethashjs": "~0.0.7",
+            "ethereumjs-block": "~2.2.2",
+            "ethereumjs-common": "^1.5.0",
+            "ethereumjs-util": "^6.1.0",
+            "flow-stoplight": "^1.0.0",
+            "level-mem": "^3.0.1",
+            "lru-cache": "^5.1.1",
+            "rlp": "^2.2.2",
+            "semaphore": "^1.1.0"
           }
         },
         "ethereumjs-common": {
@@ -6355,8 +6395,8 @@
           "integrity": "sha512-zZEK1onCeiORb0wyCXUvg94Ve5It/K6GD1K+26KfFKodiBiS6d9lfCXlUKGBBdQ+bv7Day+JK0tj1K+BeNFRAw==",
           "dev": true,
           "requires": {
-            "ethereumjs-common": "1.5.0",
-            "ethereumjs-util": "6.2.1"
+            "ethereumjs-common": "^1.5.0",
+            "ethereumjs-util": "^6.0.0"
           }
         },
         "ethereumjs-util": {
@@ -6365,13 +6405,13 @@
           "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
           "dev": true,
           "requires": {
-            "@types/bn.js": "4.11.6",
-            "bn.js": "4.11.9",
-            "create-hash": "1.2.0",
-            "elliptic": "6.5.3",
-            "ethereum-cryptography": "0.1.3",
+            "@types/bn.js": "^4.11.3",
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "elliptic": "^6.5.2",
+            "ethereum-cryptography": "^0.1.3",
             "ethjs-util": "0.1.6",
-            "rlp": "2.2.6"
+            "rlp": "^2.2.3"
           }
         },
         "ethereumjs-vm": {
@@ -6380,21 +6420,21 @@
           "integrity": "sha512-X6qqZbsY33p5FTuZqCnQ4+lo957iUJMM6Mpa6bL4UW0dxM6WmDSHuI4j/zOp1E2TDKImBGCJA9QPfc08PaNubA==",
           "dev": true,
           "requires": {
-            "async": "2.6.2",
-            "async-eventemitter": "0.2.4",
-            "core-js-pure": "3.8.2",
-            "ethereumjs-account": "3.0.0",
-            "ethereumjs-block": "2.2.2",
-            "ethereumjs-blockchain": "4.0.4",
-            "ethereumjs-common": "1.5.0",
-            "ethereumjs-tx": "2.1.2",
-            "ethereumjs-util": "6.2.1",
-            "fake-merkle-patricia-tree": "1.0.1",
-            "functional-red-black-tree": "1.0.1",
-            "merkle-patricia-tree": "2.3.2",
-            "rustbn.js": "0.2.0",
-            "safe-buffer": "5.1.2",
-            "util.promisify": "1.1.1"
+            "async": "^2.1.2",
+            "async-eventemitter": "^0.2.2",
+            "core-js-pure": "^3.0.1",
+            "ethereumjs-account": "^3.0.0",
+            "ethereumjs-block": "^2.2.2",
+            "ethereumjs-blockchain": "^4.0.3",
+            "ethereumjs-common": "^1.5.0",
+            "ethereumjs-tx": "^2.1.2",
+            "ethereumjs-util": "^6.2.0",
+            "fake-merkle-patricia-tree": "^1.0.1",
+            "functional-red-black-tree": "^1.0.1",
+            "merkle-patricia-tree": "^2.3.2",
+            "rustbn.js": "~0.2.0",
+            "safe-buffer": "^5.1.1",
+            "util.promisify": "^1.0.0"
           },
           "dependencies": {
             "abstract-leveldown": {
@@ -6403,7 +6443,7 @@
               "integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
               "dev": true,
               "requires": {
-                "xtend": "4.0.2"
+                "xtend": "~4.0.0"
               }
             },
             "deferred-leveldown": {
@@ -6412,7 +6452,7 @@
               "integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
               "dev": true,
               "requires": {
-                "abstract-leveldown": "2.6.3"
+                "abstract-leveldown": "~2.6.0"
               }
             },
             "isarray": {
@@ -6433,7 +6473,7 @@
               "integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
               "dev": true,
               "requires": {
-                "errno": "0.1.8"
+                "errno": "~0.1.1"
               }
             },
             "level-iterator-stream": {
@@ -6442,10 +6482,10 @@
               "integrity": "sha1-5Dt4sagUPm+pek9IXrjqUwNS8u0=",
               "dev": true,
               "requires": {
-                "inherits": "2.0.4",
-                "level-errors": "1.0.5",
-                "readable-stream": "1.1.14",
-                "xtend": "4.0.2"
+                "inherits": "^2.0.1",
+                "level-errors": "^1.0.3",
+                "readable-stream": "^1.0.33",
+                "xtend": "^4.0.0"
               },
               "dependencies": {
                 "readable-stream": {
@@ -6454,10 +6494,10 @@
                   "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
                   "dev": true,
                   "requires": {
-                    "core-util-is": "1.0.2",
-                    "inherits": "2.0.4",
+                    "core-util-is": "~1.0.0",
+                    "inherits": "~2.0.1",
                     "isarray": "0.0.1",
-                    "string_decoder": "0.10.31"
+                    "string_decoder": "~0.10.x"
                   }
                 }
               }
@@ -6468,8 +6508,8 @@
               "integrity": "sha1-Ny5RIXeSSgBCSwtDrvK7QkltIos=",
               "dev": true,
               "requires": {
-                "readable-stream": "1.0.34",
-                "xtend": "2.1.2"
+                "readable-stream": "~1.0.15",
+                "xtend": "~2.1.1"
               },
               "dependencies": {
                 "readable-stream": {
@@ -6478,10 +6518,10 @@
                   "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                   "dev": true,
                   "requires": {
-                    "core-util-is": "1.0.2",
-                    "inherits": "2.0.4",
+                    "core-util-is": "~1.0.0",
+                    "inherits": "~2.0.1",
                     "isarray": "0.0.1",
-                    "string_decoder": "0.10.31"
+                    "string_decoder": "~0.10.x"
                   }
                 },
                 "xtend": {
@@ -6490,7 +6530,7 @@
                   "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
                   "dev": true,
                   "requires": {
-                    "object-keys": "0.4.0"
+                    "object-keys": "~0.4.0"
                   }
                 }
               }
@@ -6501,13 +6541,13 @@
               "integrity": "sha512-VVGHfKIlmw8w1XqpGOAGwq6sZm2WwWLmlDcULkKWQXEA5EopA8OBNJ2Ck2v6bdk8HeEZSbCSEgzXadyQFm76sQ==",
               "dev": true,
               "requires": {
-                "deferred-leveldown": "1.2.2",
-                "level-codec": "7.0.1",
-                "level-errors": "1.0.5",
-                "level-iterator-stream": "1.3.1",
-                "prr": "1.0.1",
-                "semver": "5.4.1",
-                "xtend": "4.0.2"
+                "deferred-leveldown": "~1.2.1",
+                "level-codec": "~7.0.0",
+                "level-errors": "~1.0.3",
+                "level-iterator-stream": "~1.3.0",
+                "prr": "~1.0.1",
+                "semver": "~5.4.1",
+                "xtend": "~4.0.0"
               }
             },
             "ltgt": {
@@ -6522,12 +6562,12 @@
               "integrity": "sha1-tOThkhdGZP+65BNhqlAPMRnv4hU=",
               "dev": true,
               "requires": {
-                "abstract-leveldown": "2.7.2",
-                "functional-red-black-tree": "1.0.1",
-                "immediate": "3.2.3",
-                "inherits": "2.0.4",
-                "ltgt": "2.2.1",
-                "safe-buffer": "5.1.2"
+                "abstract-leveldown": "~2.7.1",
+                "functional-red-black-tree": "^1.0.1",
+                "immediate": "^3.2.3",
+                "inherits": "~2.0.1",
+                "ltgt": "~2.2.0",
+                "safe-buffer": "~5.1.1"
               },
               "dependencies": {
                 "abstract-leveldown": {
@@ -6536,7 +6576,7 @@
                   "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
                   "dev": true,
                   "requires": {
-                    "xtend": "4.0.2"
+                    "xtend": "~4.0.0"
                   }
                 }
               }
@@ -6547,14 +6587,14 @@
               "integrity": "sha512-81PW5m8oz/pz3GvsAwbauj7Y00rqm81Tzad77tHBwU7pIAtN+TJnMSOJhxBKflSVYhptMMb9RskhqHqrSm1V+g==",
               "dev": true,
               "requires": {
-                "async": "1.5.2",
-                "ethereumjs-util": "5.2.1",
+                "async": "^1.4.2",
+                "ethereumjs-util": "^5.0.0",
                 "level-ws": "0.0.0",
-                "levelup": "1.3.9",
-                "memdown": "1.4.1",
-                "readable-stream": "2.3.7",
-                "rlp": "2.2.6",
-                "semaphore": "1.1.0"
+                "levelup": "^1.2.1",
+                "memdown": "^1.0.0",
+                "readable-stream": "^2.0.0",
+                "rlp": "^2.0.0",
+                "semaphore": ">=1.0.1"
               },
               "dependencies": {
                 "async": {
@@ -6569,13 +6609,13 @@
                   "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
                   "dev": true,
                   "requires": {
-                    "bn.js": "4.11.9",
-                    "create-hash": "1.2.0",
-                    "elliptic": "6.5.3",
-                    "ethereum-cryptography": "0.1.3",
-                    "ethjs-util": "0.1.6",
-                    "rlp": "2.2.6",
-                    "safe-buffer": "5.1.2"
+                    "bn.js": "^4.11.0",
+                    "create-hash": "^1.1.2",
+                    "elliptic": "^6.5.2",
+                    "ethereum-cryptography": "^0.1.3",
+                    "ethjs-util": "^0.1.3",
+                    "rlp": "^2.0.0",
+                    "safe-buffer": "^5.1.1"
                   }
                 }
               }
@@ -6613,15 +6653,15 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "aes-js": "3.1.2",
-            "bs58check": "2.1.2",
-            "ethereum-cryptography": "0.1.3",
-            "ethereumjs-util": "6.2.1",
-            "randombytes": "2.1.0",
-            "safe-buffer": "5.2.1",
-            "scryptsy": "1.2.1",
-            "utf8": "3.0.0",
-            "uuid": "3.4.0"
+            "aes-js": "^3.1.1",
+            "bs58check": "^2.1.2",
+            "ethereum-cryptography": "^0.1.3",
+            "ethereumjs-util": "^6.0.0",
+            "randombytes": "^2.0.6",
+            "safe-buffer": "^5.1.2",
+            "scryptsy": "^1.2.1",
+            "utf8": "^3.0.0",
+            "uuid": "^3.3.2"
           }
         },
         "ethjs-unit": {
@@ -6629,6 +6669,7 @@
           "resolved": "https://registry.npmjs.org/ethjs-unit/-/ethjs-unit-0.1.6.tgz",
           "integrity": "sha1-xmWSHkduh7ziqdWIpv4EBbLEFpk=",
           "dev": true,
+          "optional": true,
           "requires": {
             "bn.js": "4.11.6",
             "number-to-bn": "1.7.0"
@@ -6638,7 +6679,8 @@
               "version": "4.11.6",
               "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
               "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -6656,7 +6698,8 @@
           "version": "4.0.4",
           "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
           "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "events": {
           "version": "3.2.0",
@@ -6670,8 +6713,8 @@
           "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
           "dev": true,
           "requires": {
-            "md5.js": "1.3.5",
-            "safe-buffer": "5.2.1"
+            "md5.js": "^1.3.4",
+            "safe-buffer": "^5.1.1"
           }
         },
         "expand-brackets": {
@@ -6680,13 +6723,13 @@
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "dev": true,
           "requires": {
-            "debug": "2.6.9",
-            "define-property": "0.2.5",
-            "extend-shallow": "2.0.1",
-            "posix-character-classes": "0.1.1",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.2",
-            "to-regex": "3.0.2"
+            "debug": "^2.3.3",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "posix-character-classes": "^0.1.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
           },
           "dependencies": {
             "debug": {
@@ -6704,7 +6747,7 @@
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "0.1.6"
+                "is-descriptor": "^0.1.0"
               }
             },
             "extend-shallow": {
@@ -6713,7 +6756,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             },
             "is-accessor-descriptor": {
@@ -6722,7 +6765,7 @@
               "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
               "dev": true,
               "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -6731,7 +6774,7 @@
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
-                    "is-buffer": "1.1.6"
+                    "is-buffer": "^1.1.5"
                   }
                 }
               }
@@ -6748,7 +6791,7 @@
               "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
               "dev": true,
               "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -6757,7 +6800,7 @@
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
-                    "is-buffer": "1.1.6"
+                    "is-buffer": "^1.1.5"
                   }
                 }
               }
@@ -6768,9 +6811,9 @@
               "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "0.1.6",
-                "is-data-descriptor": "0.1.4",
-                "kind-of": "5.1.0"
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
               }
             },
             "is-extendable": {
@@ -6800,36 +6843,36 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "accepts": "1.3.7",
+            "accepts": "~1.3.7",
             "array-flatten": "1.1.1",
             "body-parser": "1.19.0",
             "content-disposition": "0.5.3",
-            "content-type": "1.0.4",
+            "content-type": "~1.0.4",
             "cookie": "0.4.0",
             "cookie-signature": "1.0.6",
             "debug": "2.6.9",
-            "depd": "1.1.2",
-            "encodeurl": "1.0.2",
-            "escape-html": "1.0.3",
-            "etag": "1.8.1",
-            "finalhandler": "1.1.2",
+            "depd": "~1.1.2",
+            "encodeurl": "~1.0.2",
+            "escape-html": "~1.0.3",
+            "etag": "~1.8.1",
+            "finalhandler": "~1.1.2",
             "fresh": "0.5.2",
             "merge-descriptors": "1.0.1",
-            "methods": "1.1.2",
-            "on-finished": "2.3.0",
-            "parseurl": "1.3.3",
+            "methods": "~1.1.2",
+            "on-finished": "~2.3.0",
+            "parseurl": "~1.3.3",
             "path-to-regexp": "0.1.7",
-            "proxy-addr": "2.0.6",
+            "proxy-addr": "~2.0.5",
             "qs": "6.7.0",
-            "range-parser": "1.2.1",
+            "range-parser": "~1.2.1",
             "safe-buffer": "5.1.2",
             "send": "0.17.1",
             "serve-static": "1.14.1",
             "setprototypeof": "1.1.1",
-            "statuses": "1.5.0",
-            "type-is": "1.6.18",
+            "statuses": "~1.5.0",
+            "type-is": "~1.6.18",
             "utils-merge": "1.0.1",
-            "vary": "1.1.2"
+            "vary": "~1.1.2"
           },
           "dependencies": {
             "debug": {
@@ -6871,7 +6914,7 @@
           "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
           "dev": true,
           "requires": {
-            "type": "2.1.0"
+            "type": "^2.0.0"
           },
           "dependencies": {
             "type": {
@@ -6894,8 +6937,8 @@
           "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
           "dev": true,
           "requires": {
-            "assign-symbols": "1.0.0",
-            "is-extendable": "1.0.1"
+            "assign-symbols": "^1.0.0",
+            "is-extendable": "^1.0.1"
           }
         },
         "extglob": {
@@ -6904,14 +6947,14 @@
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "dev": true,
           "requires": {
-            "array-unique": "0.3.2",
-            "define-property": "1.0.0",
-            "expand-brackets": "2.1.4",
-            "extend-shallow": "2.0.1",
-            "fragment-cache": "0.2.1",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.2",
-            "to-regex": "3.0.2"
+            "array-unique": "^0.3.2",
+            "define-property": "^1.0.0",
+            "expand-brackets": "^2.1.4",
+            "extend-shallow": "^2.0.1",
+            "fragment-cache": "^0.2.1",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
           },
           "dependencies": {
             "define-property": {
@@ -6920,7 +6963,7 @@
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "1.0.2"
+                "is-descriptor": "^1.0.0"
               }
             },
             "extend-shallow": {
@@ -6929,7 +6972,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             },
             "is-extendable": {
@@ -6952,7 +6995,7 @@
           "integrity": "sha1-S4w6z7Ugr635hgsfFM2M40As3dM=",
           "dev": true,
           "requires": {
-            "checkpoint-store": "1.1.0"
+            "checkpoint-store": "^1.1.0"
           }
         },
         "fast-deep-equal": {
@@ -6973,7 +7016,7 @@
           "integrity": "sha1-rjzl9zLGReq4fkroeTQUcJsjmJM=",
           "dev": true,
           "requires": {
-            "node-fetch": "1.7.3"
+            "node-fetch": "~1.7.1"
           },
           "dependencies": {
             "is-stream": {
@@ -6988,8 +7031,8 @@
               "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
               "dev": true,
               "requires": {
-                "encoding": "0.1.13",
-                "is-stream": "1.1.0"
+                "encoding": "^0.1.11",
+                "is-stream": "^1.0.1"
               }
             }
           }
@@ -7002,12 +7045,12 @@
           "optional": true,
           "requires": {
             "debug": "2.6.9",
-            "encodeurl": "1.0.2",
-            "escape-html": "1.0.3",
-            "on-finished": "2.3.0",
-            "parseurl": "1.3.3",
-            "statuses": "1.5.0",
-            "unpipe": "1.0.0"
+            "encodeurl": "~1.0.2",
+            "escape-html": "~1.0.3",
+            "on-finished": "~2.3.0",
+            "parseurl": "~1.3.3",
+            "statuses": "~1.5.0",
+            "unpipe": "~1.0.0"
           },
           "dependencies": {
             "debug": {
@@ -7035,8 +7078,8 @@
           "integrity": "sha512-dVtfb0WuQG+8Ag2uWkbG79hOUzEsRrhBzgfn86g2sJPkzmcpGdghbNTfUKGTxymFrY/tLIodDzLoW9nOJ4FY8Q==",
           "dev": true,
           "requires": {
-            "fs-extra": "4.0.3",
-            "micromatch": "3.1.10"
+            "fs-extra": "^4.0.3",
+            "micromatch": "^3.1.4"
           },
           "dependencies": {
             "braces": {
@@ -7045,16 +7088,16 @@
               "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
               "dev": true,
               "requires": {
-                "arr-flatten": "1.1.0",
-                "array-unique": "0.3.2",
-                "extend-shallow": "2.0.1",
-                "fill-range": "4.0.0",
-                "isobject": "3.0.1",
-                "repeat-element": "1.1.3",
-                "snapdragon": "0.8.2",
-                "snapdragon-node": "2.1.1",
-                "split-string": "3.1.0",
-                "to-regex": "3.0.2"
+                "arr-flatten": "^1.1.0",
+                "array-unique": "^0.3.2",
+                "extend-shallow": "^2.0.1",
+                "fill-range": "^4.0.0",
+                "isobject": "^3.0.1",
+                "repeat-element": "^1.1.2",
+                "snapdragon": "^0.8.1",
+                "snapdragon-node": "^2.0.1",
+                "split-string": "^3.0.2",
+                "to-regex": "^3.0.1"
               },
               "dependencies": {
                 "extend-shallow": {
@@ -7063,7 +7106,7 @@
                   "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                   "dev": true,
                   "requires": {
-                    "is-extendable": "0.1.1"
+                    "is-extendable": "^0.1.0"
                   }
                 }
               }
@@ -7074,10 +7117,10 @@
               "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
               "dev": true,
               "requires": {
-                "extend-shallow": "2.0.1",
-                "is-number": "3.0.0",
-                "repeat-string": "1.6.1",
-                "to-regex-range": "2.1.1"
+                "extend-shallow": "^2.0.1",
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1",
+                "to-regex-range": "^2.1.0"
               },
               "dependencies": {
                 "extend-shallow": {
@@ -7086,7 +7129,7 @@
                   "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                   "dev": true,
                   "requires": {
-                    "is-extendable": "0.1.1"
+                    "is-extendable": "^0.1.0"
                   }
                 }
               }
@@ -7097,9 +7140,9 @@
               "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
               "dev": true,
               "requires": {
-                "graceful-fs": "4.2.4",
-                "jsonfile": "4.0.0",
-                "universalify": "0.1.2"
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
               }
             },
             "is-buffer": {
@@ -7120,7 +7163,7 @@
               "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
               "dev": true,
               "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -7129,7 +7172,7 @@
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
-                    "is-buffer": "1.1.6"
+                    "is-buffer": "^1.1.5"
                   }
                 }
               }
@@ -7140,19 +7183,19 @@
               "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
               "dev": true,
               "requires": {
-                "arr-diff": "4.0.0",
-                "array-unique": "0.3.2",
-                "braces": "2.3.2",
-                "define-property": "2.0.2",
-                "extend-shallow": "3.0.2",
-                "extglob": "2.0.4",
-                "fragment-cache": "0.2.1",
-                "kind-of": "6.0.3",
-                "nanomatch": "1.2.13",
-                "object.pick": "1.3.0",
-                "regex-not": "1.0.2",
-                "snapdragon": "0.8.2",
-                "to-regex": "3.0.2"
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "braces": "^2.3.1",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "extglob": "^2.0.4",
+                "fragment-cache": "^0.2.1",
+                "kind-of": "^6.0.2",
+                "nanomatch": "^1.2.9",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.2"
               }
             },
             "to-regex-range": {
@@ -7161,8 +7204,8 @@
               "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
               "dev": true,
               "requires": {
-                "is-number": "3.0.0",
-                "repeat-string": "1.6.1"
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1"
               }
             }
           }
@@ -7179,7 +7222,7 @@
           "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
           "dev": true,
           "requires": {
-            "is-callable": "1.2.2"
+            "is-callable": "^1.1.3"
           }
         },
         "for-in": {
@@ -7200,9 +7243,9 @@
           "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
           "dev": true,
           "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.8",
-            "mime-types": "2.1.28"
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
           }
         },
         "forwarded": {
@@ -7218,14 +7261,15 @@
           "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
           "dev": true,
           "requires": {
-            "map-cache": "0.2.2"
+            "map-cache": "^0.2.2"
           }
         },
         "fresh": {
           "version": "0.5.2",
           "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
           "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "fs-extra": {
           "version": "7.0.1",
@@ -7233,9 +7277,9 @@
           "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.2.4",
-            "jsonfile": "4.0.0",
-            "universalify": "0.1.2"
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
           }
         },
         "fs.realpath": {
@@ -7262,9 +7306,9 @@
           "integrity": "sha512-aeX0vrFm21ILl3+JpFFRNe9aUvp6VFZb2/CTbgLb8j75kOhvoNYjt9d8KA/tJG4gSo8nzEDedRl0h7vDmBYRVg==",
           "dev": true,
           "requires": {
-            "function-bind": "1.1.1",
-            "has": "1.0.3",
-            "has-symbols": "1.0.1"
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1"
           }
         },
         "get-stream": {
@@ -7274,7 +7318,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "pump": "3.0.0"
+            "pump": "^3.0.0"
           }
         },
         "get-value": {
@@ -7289,7 +7333,7 @@
           "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
           "dev": true,
           "requires": {
-            "assert-plus": "1.0.0"
+            "assert-plus": "^1.0.0"
           }
         },
         "glob": {
@@ -7298,12 +7342,12 @@
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.4",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "global": {
@@ -7312,8 +7356,8 @@
           "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
           "dev": true,
           "requires": {
-            "min-document": "2.19.0",
-            "process": "0.11.10"
+            "min-document": "^2.19.0",
+            "process": "^0.11.10"
           }
         },
         "got": {
@@ -7323,17 +7367,17 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "@sindresorhus/is": "0.14.0",
-            "@szmarczak/http-timer": "1.1.2",
-            "cacheable-request": "6.1.0",
-            "decompress-response": "3.3.0",
-            "duplexer3": "0.1.4",
-            "get-stream": "4.1.0",
-            "lowercase-keys": "1.0.1",
-            "mimic-response": "1.0.1",
-            "p-cancelable": "1.1.0",
-            "to-readable-stream": "1.0.0",
-            "url-parse-lax": "3.0.0"
+            "@sindresorhus/is": "^0.14.0",
+            "@szmarczak/http-timer": "^1.1.2",
+            "cacheable-request": "^6.0.0",
+            "decompress-response": "^3.3.0",
+            "duplexer3": "^0.1.4",
+            "get-stream": "^4.1.0",
+            "lowercase-keys": "^1.0.1",
+            "mimic-response": "^1.0.1",
+            "p-cancelable": "^1.0.0",
+            "to-readable-stream": "^1.0.0",
+            "url-parse-lax": "^3.0.0"
           },
           "dependencies": {
             "get-stream": {
@@ -7343,7 +7387,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "pump": "3.0.0"
+                "pump": "^3.0.0"
               }
             }
           }
@@ -7366,8 +7410,8 @@
           "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
           "dev": true,
           "requires": {
-            "ajv": "6.12.6",
-            "har-schema": "2.0.0"
+            "ajv": "^6.12.3",
+            "har-schema": "^2.0.0"
           }
         },
         "has": {
@@ -7376,7 +7420,7 @@
           "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
           "dev": true,
           "requires": {
-            "function-bind": "1.1.1"
+            "function-bind": "^1.1.1"
           }
         },
         "has-ansi": {
@@ -7385,7 +7429,7 @@
           "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           },
           "dependencies": {
             "ansi-regex": {
@@ -7422,7 +7466,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "has-symbol-support-x": "1.4.2"
+            "has-symbol-support-x": "^1.4.1"
           }
         },
         "has-value": {
@@ -7431,9 +7475,9 @@
           "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
           "dev": true,
           "requires": {
-            "get-value": "2.0.6",
-            "has-values": "1.0.0",
-            "isobject": "3.0.1"
+            "get-value": "^2.0.6",
+            "has-values": "^1.0.0",
+            "isobject": "^3.0.0"
           }
         },
         "has-values": {
@@ -7442,8 +7486,8 @@
           "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
           "dev": true,
           "requires": {
-            "is-number": "3.0.0",
-            "kind-of": "4.0.0"
+            "is-number": "^3.0.0",
+            "kind-of": "^4.0.0"
           },
           "dependencies": {
             "is-buffer": {
@@ -7458,7 +7502,7 @@
               "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
               "dev": true,
               "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -7467,7 +7511,7 @@
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
-                    "is-buffer": "1.1.6"
+                    "is-buffer": "^1.1.5"
                   }
                 }
               }
@@ -7478,7 +7522,7 @@
               "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -7489,9 +7533,9 @@
           "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
           "dev": true,
           "requires": {
-            "inherits": "2.0.4",
-            "readable-stream": "3.6.0",
-            "safe-buffer": "5.2.1"
+            "inherits": "^2.0.4",
+            "readable-stream": "^3.6.0",
+            "safe-buffer": "^5.2.0"
           },
           "dependencies": {
             "readable-stream": {
@@ -7500,9 +7544,9 @@
               "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
               "dev": true,
               "requires": {
-                "inherits": "2.0.4",
-                "string_decoder": "1.1.1",
-                "util-deprecate": "1.0.2"
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
               }
             }
           }
@@ -7513,8 +7557,8 @@
           "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
           "dev": true,
           "requires": {
-            "inherits": "2.0.4",
-            "minimalistic-assert": "1.0.1"
+            "inherits": "^2.0.3",
+            "minimalistic-assert": "^1.0.1"
           }
         },
         "heap": {
@@ -7529,9 +7573,9 @@
           "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
           "dev": true,
           "requires": {
-            "hash.js": "1.1.7",
-            "minimalistic-assert": "1.0.1",
-            "minimalistic-crypto-utils": "1.0.1"
+            "hash.js": "^1.0.3",
+            "minimalistic-assert": "^1.0.0",
+            "minimalistic-crypto-utils": "^1.0.1"
           }
         },
         "home-or-tmp": {
@@ -7540,8 +7584,8 @@
           "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
           "dev": true,
           "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.1"
           }
         },
         "http-cache-semantics": {
@@ -7556,11 +7600,12 @@
           "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
           "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
           "dev": true,
+          "optional": true,
           "requires": {
-            "depd": "1.1.2",
+            "depd": "~1.1.2",
             "inherits": "2.0.3",
             "setprototypeof": "1.1.1",
-            "statuses": "1.5.0",
+            "statuses": ">= 1.5.0 < 2",
             "toidentifier": "1.0.0"
           },
           "dependencies": {
@@ -7568,7 +7613,8 @@
               "version": "2.0.3",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
               "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -7576,7 +7622,8 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/http-https/-/http-https-1.0.0.tgz",
           "integrity": "sha1-L5CN1fHbQGjAWM1ubUzjkskTOJs=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "http-signature": {
           "version": "1.2.0",
@@ -7584,9 +7631,9 @@
           "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
           "dev": true,
           "requires": {
-            "assert-plus": "1.0.0",
-            "jsprim": "1.4.1",
-            "sshpk": "1.16.1"
+            "assert-plus": "^1.0.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
           }
         },
         "iconv-lite": {
@@ -7594,8 +7641,9 @@
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
           "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
           "dev": true,
+          "optional": true,
           "requires": {
-            "safer-buffer": "2.1.2"
+            "safer-buffer": ">= 2.1.2 < 3"
           }
         },
         "idna-uts46-hx": {
@@ -7635,8 +7683,8 @@
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
         "inherits": {
@@ -7651,7 +7699,7 @@
           "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
           "dev": true,
           "requires": {
-            "loose-envify": "1.4.0"
+            "loose-envify": "^1.0.0"
           }
         },
         "ipaddr.js": {
@@ -7667,7 +7715,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.3"
+            "kind-of": "^6.0.0"
           }
         },
         "is-arguments": {
@@ -7676,7 +7724,7 @@
           "integrity": "sha512-1Ij4lOMPl/xB5kBDn7I+b2ttPMKa8szhEIrXDuXQD/oe3HJLTLhqhgGspwgyGd6MOywBUqVvYicF72lkgDnIHg==",
           "dev": true,
           "requires": {
-            "call-bind": "1.0.2"
+            "call-bind": "^1.0.0"
           }
         },
         "is-callable": {
@@ -7691,7 +7739,7 @@
           "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
           "dev": true,
           "requires": {
-            "ci-info": "2.0.0"
+            "ci-info": "^2.0.0"
           }
         },
         "is-data-descriptor": {
@@ -7700,7 +7748,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.3"
+            "kind-of": "^6.0.0"
           }
         },
         "is-date-object": {
@@ -7715,9 +7763,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.3"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         },
         "is-extendable": {
@@ -7726,7 +7774,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "2.0.4"
+            "is-plain-object": "^2.0.4"
           }
         },
         "is-finite": {
@@ -7779,7 +7827,7 @@
           "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
           "dev": true,
           "requires": {
-            "isobject": "3.0.1"
+            "isobject": "^3.0.1"
           }
         },
         "is-regex": {
@@ -7788,7 +7836,7 @@
           "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
           "dev": true,
           "requires": {
-            "has-symbols": "1.0.1"
+            "has-symbols": "^1.0.1"
           }
         },
         "is-retry-allowed": {
@@ -7804,7 +7852,7 @@
           "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
           "dev": true,
           "requires": {
-            "has-symbols": "1.0.1"
+            "has-symbols": "^1.0.1"
           }
         },
         "is-typedarray": {
@@ -7850,15 +7898,16 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "has-to-string-tag-x": "1.4.1",
-            "is-object": "1.0.2"
+            "has-to-string-tag-x": "^1.2.0",
+            "is-object": "^1.0.1"
           }
         },
         "js-sha3": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
           "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "js-tokens": {
           "version": "4.0.0",
@@ -7885,12 +7934,12 @@
           "integrity": "sha512-6QNcvm2gFuuK4TKU1uwfH0Qd/cOSb9c1lls0gbnIhciktIUQJwz6NQNAW4B1KiGPenv7IKu97V222Yo1bNhGuA==",
           "dev": true,
           "requires": {
-            "async": "2.6.2",
-            "babel-preset-env": "1.7.0",
-            "babelify": "7.3.0",
-            "json-rpc-error": "2.0.0",
-            "promise-to-callback": "1.0.0",
-            "safe-event-emitter": "1.0.1"
+            "async": "^2.0.1",
+            "babel-preset-env": "^1.7.0",
+            "babelify": "^7.3.0",
+            "json-rpc-error": "^2.0.0",
+            "promise-to-callback": "^1.0.0",
+            "safe-event-emitter": "^1.0.1"
           }
         },
         "json-rpc-error": {
@@ -7899,7 +7948,7 @@
           "integrity": "sha1-p6+cICg4tekFxyUOVH8a/3cligI=",
           "dev": true,
           "requires": {
-            "inherits": "2.0.4"
+            "inherits": "^2.0.1"
           }
         },
         "json-rpc-random-id": {
@@ -7926,7 +7975,7 @@
           "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
           "dev": true,
           "requires": {
-            "jsonify": "0.0.0"
+            "jsonify": "~0.0.0"
           }
         },
         "json-stringify-safe": {
@@ -7941,7 +7990,7 @@
           "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.2.4"
+            "graceful-fs": "^4.1.6"
           }
         },
         "jsonify": {
@@ -7964,10 +8013,12 @@
         },
         "keccak": {
           "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.1.tgz",
+          "integrity": "sha512-epq90L9jlFWCW7+pQa6JOnKn2Xgl2mtI664seYR6MHskvI9agt7AnDqmAlp9TqU4/caMYbA08Hi5DMZAl5zdkA==",
           "dev": true,
           "requires": {
-            "node-addon-api": "2.0.2",
-            "node-gyp-build": "4.2.3"
+            "node-addon-api": "^2.0.0",
+            "node-gyp-build": "^4.2.0"
           }
         },
         "keyv": {
@@ -7992,7 +8043,7 @@
           "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.2.4"
+            "graceful-fs": "^4.1.11"
           }
         },
         "level-codec": {
@@ -8001,7 +8052,7 @@
           "integrity": "sha512-UyIwNb1lJBChJnGfjmO0OR+ezh2iVu1Kas3nvBS/BzGnx79dv6g7unpKIDNPMhfdTEGoc7mC8uAu51XEtX+FHQ==",
           "dev": true,
           "requires": {
-            "buffer": "5.7.1"
+            "buffer": "^5.6.0"
           }
         },
         "level-errors": {
@@ -8010,7 +8061,7 @@
           "integrity": "sha512-UVprBJXite4gPS+3VznfgDSU8PTRuVX0NXwoWW50KLxd2yw4Y1t2JUR5In1itQnudZqRMT9DlAM3Q//9NCjCFw==",
           "dev": true,
           "requires": {
-            "errno": "0.1.8"
+            "errno": "~0.1.1"
           }
         },
         "level-iterator-stream": {
@@ -8019,9 +8070,9 @@
           "integrity": "sha512-I6Heg70nfF+e5Y3/qfthJFexhRw/Gi3bIymCoXAlijZdAcLaPuWSJs3KXyTYf23ID6g0o2QF62Yh+grOXY3Rig==",
           "dev": true,
           "requires": {
-            "inherits": "2.0.4",
-            "readable-stream": "2.3.7",
-            "xtend": "4.0.2"
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.0.5",
+            "xtend": "^4.0.0"
           }
         },
         "level-mem": {
@@ -8030,8 +8081,8 @@
           "integrity": "sha512-LbtfK9+3Ug1UmvvhR2DqLqXiPW1OJ5jEh0a3m9ZgAipiwpSxGj/qaVVy54RG5vAQN1nCuXqjvprCuKSCxcJHBg==",
           "dev": true,
           "requires": {
-            "level-packager": "4.0.1",
-            "memdown": "3.0.0"
+            "level-packager": "~4.0.0",
+            "memdown": "~3.0.0"
           },
           "dependencies": {
             "abstract-leveldown": {
@@ -8040,7 +8091,7 @@
               "integrity": "sha512-5mU5P1gXtsMIXg65/rsYGsi93+MlogXZ9FA8JnwKurHQg64bfXwGYVdVdijNTVNOlAsuIiOwHdvFFD5JqCJQ7A==",
               "dev": true,
               "requires": {
-                "xtend": "4.0.2"
+                "xtend": "~4.0.0"
               }
             },
             "ltgt": {
@@ -8055,12 +8106,12 @@
               "integrity": "sha512-tbV02LfZMWLcHcq4tw++NuqMO+FZX8tNJEiD2aNRm48ZZusVg5N8NART+dmBkepJVye986oixErf7jfXboMGMA==",
               "dev": true,
               "requires": {
-                "abstract-leveldown": "5.0.0",
-                "functional-red-black-tree": "1.0.1",
-                "immediate": "3.2.3",
-                "inherits": "2.0.4",
-                "ltgt": "2.2.1",
-                "safe-buffer": "5.1.2"
+                "abstract-leveldown": "~5.0.0",
+                "functional-red-black-tree": "~1.0.1",
+                "immediate": "~3.2.3",
+                "inherits": "~2.0.1",
+                "ltgt": "~2.2.0",
+                "safe-buffer": "~5.1.1"
               }
             },
             "safe-buffer": {
@@ -8077,8 +8128,8 @@
           "integrity": "sha512-svCRKfYLn9/4CoFfi+d8krOtrp6RoX8+xm0Na5cgXMqSyRru0AnDYdLl+YI8u1FyS6gGZ94ILLZDE5dh2but3Q==",
           "dev": true,
           "requires": {
-            "encoding-down": "5.0.4",
-            "levelup": "3.1.1"
+            "encoding-down": "~5.0.0",
+            "levelup": "^3.0.0"
           }
         },
         "level-post": {
@@ -8087,7 +8138,7 @@
           "integrity": "sha512-PWYqG4Q00asOrLhX7BejSajByB4EmG2GaKHfj3h5UmmZ2duciXLPGYWIjBzLECFWUGOZWlm5B20h/n3Gs3HKew==",
           "dev": true,
           "requires": {
-            "ltgt": "2.1.3"
+            "ltgt": "^2.1.2"
           }
         },
         "level-sublevel": {
@@ -8096,16 +8147,16 @@
           "integrity": "sha512-pcCrTUOiO48+Kp6F1+UAzF/OtWqLcQVTVF39HLdZ3RO8XBoXt+XVPKZO1vVr1aUoxHZA9OtD2e1v7G+3S5KFDA==",
           "dev": true,
           "requires": {
-            "bytewise": "1.1.0",
-            "level-codec": "9.0.2",
-            "level-errors": "2.0.1",
-            "level-iterator-stream": "2.0.3",
-            "ltgt": "2.1.3",
-            "pull-defer": "0.2.3",
-            "pull-level": "2.0.4",
-            "pull-stream": "3.6.14",
-            "typewiselite": "1.0.0",
-            "xtend": "4.0.2"
+            "bytewise": "~1.1.0",
+            "level-codec": "^9.0.0",
+            "level-errors": "^2.0.0",
+            "level-iterator-stream": "^2.0.3",
+            "ltgt": "~2.1.1",
+            "pull-defer": "^0.2.2",
+            "pull-level": "^2.0.3",
+            "pull-stream": "^3.6.8",
+            "typewiselite": "~1.0.0",
+            "xtend": "~4.0.0"
           }
         },
         "level-ws": {
@@ -8114,9 +8165,9 @@
           "integrity": "sha512-RXEfCmkd6WWFlArh3X8ONvQPm8jNpfA0s/36M4QzLqrLEIt1iJE9WBHLZ5vZJK6haMjJPJGJCQWfjMNnRcq/9Q==",
           "dev": true,
           "requires": {
-            "inherits": "2.0.4",
-            "readable-stream": "2.3.7",
-            "xtend": "4.0.2"
+            "inherits": "^2.0.3",
+            "readable-stream": "^2.2.8",
+            "xtend": "^4.0.1"
           }
         },
         "levelup": {
@@ -8125,10 +8176,10 @@
           "integrity": "sha512-9N10xRkUU4dShSRRFTBdNaBxofz+PGaIZO962ckboJZiNmLuhVT6FZ6ZKAsICKfUBO76ySaYU6fJWX/jnj3Lcg==",
           "dev": true,
           "requires": {
-            "deferred-leveldown": "4.0.2",
-            "level-errors": "2.0.1",
-            "level-iterator-stream": "3.0.1",
-            "xtend": "4.0.2"
+            "deferred-leveldown": "~4.0.0",
+            "level-errors": "~2.0.0",
+            "level-iterator-stream": "~3.0.0",
+            "xtend": "~4.0.0"
           },
           "dependencies": {
             "level-iterator-stream": {
@@ -8137,9 +8188,9 @@
               "integrity": "sha512-nEIQvxEED9yRThxvOrq8Aqziy4EGzrxSZK+QzEFAVuJvQ8glfyZ96GB6BoI4sBbLfjMXm2w4vu3Tkcm9obcY0g==",
               "dev": true,
               "requires": {
-                "inherits": "2.0.4",
-                "readable-stream": "2.3.7",
-                "xtend": "4.0.2"
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.3.6",
+                "xtend": "^4.0.0"
               }
             }
           }
@@ -8162,14 +8213,15 @@
           "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
           "dev": true,
           "requires": {
-            "js-tokens": "4.0.0"
+            "js-tokens": "^3.0.0 || ^4.0.0"
           }
         },
         "lowercase-keys": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
           "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "lru-cache": {
           "version": "5.1.1",
@@ -8177,7 +8229,7 @@
           "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
           "dev": true,
           "requires": {
-            "yallist": "3.1.1"
+            "yallist": "^3.0.2"
           }
         },
         "ltgt": {
@@ -8198,7 +8250,7 @@
           "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
           "dev": true,
           "requires": {
-            "object-visit": "1.0.1"
+            "object-visit": "^1.0.0"
           }
         },
         "md5.js": {
@@ -8207,16 +8259,17 @@
           "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
           "dev": true,
           "requires": {
-            "hash-base": "3.1.0",
-            "inherits": "2.0.4",
-            "safe-buffer": "5.2.1"
+            "hash-base": "^3.0.0",
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.1.2"
           }
         },
         "media-typer": {
           "version": "0.3.0",
           "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
           "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "merge-descriptors": {
           "version": "1.0.1",
@@ -8231,13 +8284,13 @@
           "integrity": "sha512-soRaMuNf/ILmw3KWbybaCjhx86EYeBbD8ph0edQCTed0JN/rxDt1EBN52Ajre3VyGo+91f8+/rfPIRQnnGMqmQ==",
           "dev": true,
           "requires": {
-            "async": "2.6.2",
-            "ethereumjs-util": "5.2.1",
-            "level-mem": "3.0.1",
-            "level-ws": "1.0.0",
-            "readable-stream": "3.6.0",
-            "rlp": "2.2.6",
-            "semaphore": "1.1.0"
+            "async": "^2.6.1",
+            "ethereumjs-util": "^5.2.0",
+            "level-mem": "^3.0.1",
+            "level-ws": "^1.0.0",
+            "readable-stream": "^3.0.6",
+            "rlp": "^2.0.0",
+            "semaphore": ">=1.0.1"
           },
           "dependencies": {
             "ethereumjs-util": {
@@ -8246,13 +8299,13 @@
               "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
               "dev": true,
               "requires": {
-                "bn.js": "4.11.9",
-                "create-hash": "1.2.0",
-                "elliptic": "6.5.3",
-                "ethereum-cryptography": "0.1.3",
-                "ethjs-util": "0.1.6",
-                "rlp": "2.2.6",
-                "safe-buffer": "5.2.1"
+                "bn.js": "^4.11.0",
+                "create-hash": "^1.1.2",
+                "elliptic": "^6.5.2",
+                "ethereum-cryptography": "^0.1.3",
+                "ethjs-util": "^0.1.3",
+                "rlp": "^2.0.0",
+                "safe-buffer": "^5.1.1"
               }
             },
             "readable-stream": {
@@ -8261,9 +8314,9 @@
               "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
               "dev": true,
               "requires": {
-                "inherits": "2.0.4",
-                "string_decoder": "1.1.1",
-                "util-deprecate": "1.0.2"
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
               }
             }
           }
@@ -8281,15 +8334,16 @@
           "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
           "dev": true,
           "requires": {
-            "bn.js": "4.11.9",
-            "brorand": "1.1.0"
+            "bn.js": "^4.0.0",
+            "brorand": "^1.0.1"
           }
         },
         "mime": {
           "version": "1.6.0",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
           "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "mime-db": {
           "version": "1.45.0",
@@ -8310,7 +8364,8 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
           "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "min-document": {
           "version": "2.19.0",
@@ -8318,7 +8373,7 @@
           "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
           "dev": true,
           "requires": {
-            "dom-walk": "0.1.2"
+            "dom-walk": "^0.1.0"
           }
         },
         "minimalistic-assert": {
@@ -8339,7 +8394,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.11"
+            "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
@@ -8355,7 +8410,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "2.9.0"
+            "minipass": "^2.9.0"
           },
           "dependencies": {
             "minipass": {
@@ -8365,8 +8420,8 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "safe-buffer": "5.2.1",
-                "yallist": "3.1.1"
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.0"
               }
             }
           }
@@ -8377,8 +8432,8 @@
           "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
           "dev": true,
           "requires": {
-            "for-in": "1.0.2",
-            "is-extendable": "1.0.1"
+            "for-in": "^1.0.2",
+            "is-extendable": "^1.0.1"
           }
         },
         "mkdirp": {
@@ -8387,7 +8442,7 @@
           "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
           "dev": true,
           "requires": {
-            "minimist": "1.2.5"
+            "minimist": "^1.2.5"
           }
         },
         "mkdirp-promise": {
@@ -8397,7 +8452,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "mkdirp": "0.5.5"
+            "mkdirp": "*"
           }
         },
         "mock-fs": {
@@ -8420,8 +8475,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "base-x": "3.0.8",
-            "buffer": "5.7.1"
+            "base-x": "^3.0.8",
+            "buffer": "^5.5.0"
           }
         },
         "multicodec": {
@@ -8431,7 +8486,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "varint": "5.0.2"
+            "varint": "^5.0.0"
           }
         },
         "multihashes": {
@@ -8439,10 +8494,11 @@
           "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.4.21.tgz",
           "integrity": "sha512-uVSvmeCWf36pU2nB4/1kzYZjsXD9vofZKpgudqkceYY5g2aZZXJ5r9lxuzoRLl1OAp28XljXsEJ/X/85ZsKmKw==",
           "dev": true,
+          "optional": true,
           "requires": {
-            "buffer": "5.7.1",
-            "multibase": "0.7.0",
-            "varint": "5.0.2"
+            "buffer": "^5.5.0",
+            "multibase": "^0.7.0",
+            "varint": "^5.0.0"
           },
           "dependencies": {
             "multibase": {
@@ -8450,9 +8506,10 @@
               "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
               "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
               "dev": true,
+              "optional": true,
               "requires": {
-                "base-x": "3.0.8",
-                "buffer": "5.7.1"
+                "base-x": "^3.0.8",
+                "buffer": "^5.5.0"
               }
             }
           }
@@ -8470,17 +8527,17 @@
           "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
           "dev": true,
           "requires": {
-            "arr-diff": "4.0.0",
-            "array-unique": "0.3.2",
-            "define-property": "2.0.2",
-            "extend-shallow": "3.0.2",
-            "fragment-cache": "0.2.1",
-            "is-windows": "1.0.2",
-            "kind-of": "6.0.3",
-            "object.pick": "1.3.0",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.2",
-            "to-regex": "3.0.2"
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "fragment-cache": "^0.2.1",
+            "is-windows": "^1.0.2",
+            "kind-of": "^6.0.2",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
           }
         },
         "negotiator": {
@@ -8504,6 +8561,8 @@
         },
         "node-addon-api": {
           "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
+          "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==",
           "dev": true
         },
         "node-fetch": {
@@ -8514,6 +8573,8 @@
         },
         "node-gyp-build": {
           "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
+          "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==",
           "dev": true
         },
         "normalize-url": {
@@ -8528,6 +8589,7 @@
           "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
           "integrity": "sha1-uzYjWS9+X54AMLGXe9QaDFP+HqA=",
           "dev": true,
+          "optional": true,
           "requires": {
             "bn.js": "4.11.6",
             "strip-hex-prefix": "1.0.0"
@@ -8537,7 +8599,8 @@
               "version": "4.11.6",
               "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
               "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -8559,9 +8622,9 @@
           "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
           "dev": true,
           "requires": {
-            "copy-descriptor": "0.1.1",
-            "define-property": "0.2.5",
-            "kind-of": "3.2.2"
+            "copy-descriptor": "^0.1.0",
+            "define-property": "^0.2.5",
+            "kind-of": "^3.0.3"
           },
           "dependencies": {
             "define-property": {
@@ -8570,7 +8633,7 @@
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "0.1.6"
+                "is-descriptor": "^0.1.0"
               }
             },
             "is-accessor-descriptor": {
@@ -8579,7 +8642,7 @@
               "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
               "dev": true,
               "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
               }
             },
             "is-buffer": {
@@ -8594,7 +8657,7 @@
               "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
               "dev": true,
               "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
               }
             },
             "is-descriptor": {
@@ -8603,9 +8666,9 @@
               "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "0.1.6",
-                "is-data-descriptor": "0.1.4",
-                "kind-of": "5.1.0"
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
               },
               "dependencies": {
                 "kind-of": {
@@ -8622,7 +8685,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -8639,8 +8702,8 @@
           "integrity": "sha512-1ZvAZ4wlF7IyPVOcE1Omikt7UpaFlOQq0HlSti+ZvDH3UiD2brwGMwDbyV43jao2bKJ+4+WdPJHSd7kgzKYVqg==",
           "dev": true,
           "requires": {
-            "call-bind": "1.0.2",
-            "define-properties": "1.1.3"
+            "call-bind": "^1.0.0",
+            "define-properties": "^1.1.3"
           }
         },
         "object-keys": {
@@ -8655,7 +8718,7 @@
           "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
           "dev": true,
           "requires": {
-            "isobject": "3.0.1"
+            "isobject": "^3.0.0"
           }
         },
         "object.assign": {
@@ -8664,10 +8727,10 @@
           "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
           "dev": true,
           "requires": {
-            "call-bind": "1.0.2",
-            "define-properties": "1.1.3",
-            "has-symbols": "1.0.1",
-            "object-keys": "1.1.1"
+            "call-bind": "^1.0.0",
+            "define-properties": "^1.1.3",
+            "has-symbols": "^1.0.1",
+            "object-keys": "^1.1.1"
           }
         },
         "object.getownpropertydescriptors": {
@@ -8676,9 +8739,9 @@
           "integrity": "sha512-6DtXgZ/lIZ9hqx4GtZETobXLR/ZLaa0aqV0kzbn80Rf8Z2e/XFnhA0I7p07N2wH8bBBltr2xQPi6sbKWAY2Eng==",
           "dev": true,
           "requires": {
-            "call-bind": "1.0.2",
-            "define-properties": "1.1.3",
-            "es-abstract": "1.18.0-next.1"
+            "call-bind": "^1.0.0",
+            "define-properties": "^1.1.3",
+            "es-abstract": "^1.18.0-next.1"
           }
         },
         "object.pick": {
@@ -8687,7 +8750,7 @@
           "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
           "dev": true,
           "requires": {
-            "isobject": "3.0.1"
+            "isobject": "^3.0.1"
           }
         },
         "oboe": {
@@ -8695,8 +8758,9 @@
           "resolved": "https://registry.npmjs.org/oboe/-/oboe-2.1.4.tgz",
           "integrity": "sha1-IMiM2wwVNxuwQRklfU/dNLCqSfY=",
           "dev": true,
+          "optional": true,
           "requires": {
-            "http-https": "1.0.0"
+            "http-https": "^1.0.0"
           }
         },
         "on-finished": {
@@ -8704,6 +8768,7 @@
           "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
           "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ee-first": "1.1.1"
           }
@@ -8714,7 +8779,7 @@
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "os-homedir": {
@@ -8743,7 +8808,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "p-finally": "1.0.0"
+            "p-finally": "^1.0.0"
           },
           "dependencies": {
             "p-finally": {
@@ -8760,12 +8825,13 @@
           "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.6.tgz",
           "integrity": "sha512-RnZRo1EPU6JBnra2vGHj0yhp6ebyjBZpmUCLHWiFhxlzvBCCpAuZ7elsBp1PVAbQN0/04VD/19rfzlBSwLstMw==",
           "dev": true,
+          "optional": true,
           "requires": {
-            "asn1.js": "5.4.1",
-            "browserify-aes": "1.2.0",
-            "evp_bytestokey": "1.0.3",
-            "pbkdf2": "3.1.1",
-            "safe-buffer": "5.2.1"
+            "asn1.js": "^5.2.0",
+            "browserify-aes": "^1.0.0",
+            "evp_bytestokey": "^1.0.0",
+            "pbkdf2": "^3.0.3",
+            "safe-buffer": "^5.1.1"
           }
         },
         "parse-headers": {
@@ -8778,7 +8844,8 @@
           "version": "1.3.3",
           "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
           "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "pascalcase": {
           "version": "0.1.1",
@@ -8792,18 +8859,18 @@
           "integrity": "sha512-YqScVYkVcClUY0v8fF0kWOjDYopzIM8e3bj/RU1DPeEF14+dCGm6UeOYm4jvCyxqIEQ5/eJzmbWfDWnUleFNMg==",
           "dev": true,
           "requires": {
-            "@yarnpkg/lockfile": "1.1.0",
-            "chalk": "2.4.2",
-            "cross-spawn": "6.0.5",
-            "find-yarn-workspace-root": "1.2.1",
-            "fs-extra": "7.0.1",
-            "is-ci": "2.0.0",
-            "klaw-sync": "6.0.0",
-            "minimist": "1.2.5",
-            "rimraf": "2.6.3",
-            "semver": "5.7.1",
-            "slash": "2.0.0",
-            "tmp": "0.0.33"
+            "@yarnpkg/lockfile": "^1.1.0",
+            "chalk": "^2.4.2",
+            "cross-spawn": "^6.0.5",
+            "find-yarn-workspace-root": "^1.2.1",
+            "fs-extra": "^7.0.1",
+            "is-ci": "^2.0.0",
+            "klaw-sync": "^6.0.0",
+            "minimist": "^1.2.0",
+            "rimraf": "^2.6.3",
+            "semver": "^5.6.0",
+            "slash": "^2.0.0",
+            "tmp": "^0.0.33"
           },
           "dependencies": {
             "cross-spawn": {
@@ -8812,11 +8879,11 @@
               "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
               "dev": true,
               "requires": {
-                "nice-try": "1.0.5",
-                "path-key": "2.0.1",
-                "semver": "5.7.1",
-                "shebang-command": "1.2.0",
-                "which": "1.3.1"
+                "nice-try": "^1.0.4",
+                "path-key": "^2.0.1",
+                "semver": "^5.5.0",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
               }
             },
             "path-key": {
@@ -8837,7 +8904,7 @@
               "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
               "dev": true,
               "requires": {
-                "shebang-regex": "1.0.0"
+                "shebang-regex": "^1.0.0"
               }
             },
             "shebang-regex": {
@@ -8858,7 +8925,7 @@
               "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
               "dev": true,
               "requires": {
-                "os-tmpdir": "1.0.2"
+                "os-tmpdir": "~1.0.2"
               }
             },
             "which": {
@@ -8867,7 +8934,7 @@
               "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
               "dev": true,
               "requires": {
-                "isexe": "2.0.0"
+                "isexe": "^2.0.0"
               }
             }
           }
@@ -8897,11 +8964,11 @@
           "integrity": "sha512-4Ejy1OPxi9f2tt1rRV7Go7zmfDQ+ZectEQz3VGUQhgq62HtIRPDyG/JtnwIxs6x3uNMwo2V7q1fMvKjb+Tnpqg==",
           "dev": true,
           "requires": {
-            "create-hash": "1.2.0",
-            "create-hmac": "1.1.7",
-            "ripemd160": "2.0.2",
-            "safe-buffer": "5.2.1",
-            "sha.js": "2.4.11"
+            "create-hash": "^1.1.2",
+            "create-hmac": "^1.1.4",
+            "ripemd160": "^2.0.1",
+            "safe-buffer": "^5.0.1",
+            "sha.js": "^2.4.8"
           }
         },
         "performance-now": {
@@ -8953,8 +9020,8 @@
           "integrity": "sha1-XSp0kBC/tn2WNZj805YHRqaP7vc=",
           "dev": true,
           "requires": {
-            "is-fn": "1.0.0",
-            "set-immediate-shim": "1.0.1"
+            "is-fn": "^1.0.0",
+            "set-immediate-shim": "^1.0.1"
           }
         },
         "proxy-addr": {
@@ -8964,7 +9031,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "forwarded": "0.1.2",
+            "forwarded": "~0.1.2",
             "ipaddr.js": "1.9.1"
           }
         },
@@ -8993,12 +9060,12 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "bn.js": "4.11.9",
-            "browserify-rsa": "4.1.0",
-            "create-hash": "1.2.0",
-            "parse-asn1": "5.1.6",
-            "randombytes": "2.1.0",
-            "safe-buffer": "5.2.1"
+            "bn.js": "^4.1.0",
+            "browserify-rsa": "^4.0.0",
+            "create-hash": "^1.1.0",
+            "parse-asn1": "^5.0.0",
+            "randombytes": "^2.0.1",
+            "safe-buffer": "^5.1.2"
           }
         },
         "pull-cat": {
@@ -9019,13 +9086,13 @@
           "integrity": "sha512-fW6pljDeUThpq5KXwKbRG3X7Ogk3vc75d5OQU/TvXXui65ykm+Bn+fiktg+MOx2jJ85cd+sheufPL+rw9QSVZg==",
           "dev": true,
           "requires": {
-            "level-post": "1.0.7",
-            "pull-cat": "1.1.11",
-            "pull-live": "1.0.1",
-            "pull-pushable": "2.2.0",
-            "pull-stream": "3.6.14",
-            "pull-window": "2.1.4",
-            "stream-to-pull-stream": "1.7.3"
+            "level-post": "^1.0.7",
+            "pull-cat": "^1.1.9",
+            "pull-live": "^1.0.1",
+            "pull-pushable": "^2.0.0",
+            "pull-stream": "^3.4.0",
+            "pull-window": "^2.1.4",
+            "stream-to-pull-stream": "^1.7.1"
           }
         },
         "pull-live": {
@@ -9034,8 +9101,8 @@
           "integrity": "sha1-pOzuAeMwFV6RJLu89HYfIbOPUfU=",
           "dev": true,
           "requires": {
-            "pull-cat": "1.1.11",
-            "pull-stream": "3.6.14"
+            "pull-cat": "^1.1.9",
+            "pull-stream": "^3.4.0"
           }
         },
         "pull-pushable": {
@@ -9056,7 +9123,7 @@
           "integrity": "sha1-/DuG/uvRkgx64pdpHiP3BfiFUvA=",
           "dev": true,
           "requires": {
-            "looper": "2.0.0"
+            "looper": "^2.0.0"
           }
         },
         "pump": {
@@ -9064,9 +9131,10 @@
           "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
           "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
           "dev": true,
+          "optional": true,
           "requires": {
-            "end-of-stream": "1.4.4",
-            "once": "1.4.0"
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
           }
         },
         "punycode": {
@@ -9086,10 +9154,11 @@
           "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
           "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
           "dev": true,
+          "optional": true,
           "requires": {
-            "decode-uri-component": "0.2.0",
-            "object-assign": "4.1.1",
-            "strict-uri-encode": "1.1.0"
+            "decode-uri-component": "^0.2.0",
+            "object-assign": "^4.1.0",
+            "strict-uri-encode": "^1.0.0"
           }
         },
         "randombytes": {
@@ -9098,7 +9167,7 @@
           "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.2.1"
+            "safe-buffer": "^5.1.0"
           }
         },
         "randomfill": {
@@ -9108,21 +9177,23 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "randombytes": "2.1.0",
-            "safe-buffer": "5.2.1"
+            "randombytes": "^2.0.5",
+            "safe-buffer": "^5.1.0"
           }
         },
         "range-parser": {
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
           "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "raw-body": {
           "version": "2.4.0",
           "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
           "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
           "dev": true,
+          "optional": true,
           "requires": {
             "bytes": "3.1.0",
             "http-errors": "1.7.2",
@@ -9136,13 +9207,13 @@
           "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.4",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.1",
-            "safe-buffer": "5.1.2",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           },
           "dependencies": {
             "safe-buffer": {
@@ -9171,9 +9242,9 @@
           "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "private": "0.1.8"
+            "babel-runtime": "^6.18.0",
+            "babel-types": "^6.19.0",
+            "private": "^0.1.6"
           }
         },
         "regex-not": {
@@ -9182,8 +9253,8 @@
           "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
           "dev": true,
           "requires": {
-            "extend-shallow": "3.0.2",
-            "safe-regex": "1.1.0"
+            "extend-shallow": "^3.0.2",
+            "safe-regex": "^1.1.0"
           }
         },
         "regexp.prototype.flags": {
@@ -9192,8 +9263,8 @@
           "integrity": "sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==",
           "dev": true,
           "requires": {
-            "define-properties": "1.1.3",
-            "es-abstract": "1.17.7"
+            "define-properties": "^1.1.3",
+            "es-abstract": "^1.17.0-next.1"
           },
           "dependencies": {
             "es-abstract": {
@@ -9202,17 +9273,17 @@
               "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
               "dev": true,
               "requires": {
-                "es-to-primitive": "1.2.1",
-                "function-bind": "1.1.1",
-                "has": "1.0.3",
-                "has-symbols": "1.0.1",
-                "is-callable": "1.2.2",
-                "is-regex": "1.1.1",
-                "object-inspect": "1.9.0",
-                "object-keys": "1.1.1",
-                "object.assign": "4.1.2",
-                "string.prototype.trimend": "1.0.3",
-                "string.prototype.trimstart": "1.0.3"
+                "es-to-primitive": "^1.2.1",
+                "function-bind": "^1.1.1",
+                "has": "^1.0.3",
+                "has-symbols": "^1.0.1",
+                "is-callable": "^1.2.2",
+                "is-regex": "^1.1.1",
+                "object-inspect": "^1.8.0",
+                "object-keys": "^1.1.1",
+                "object.assign": "^4.1.1",
+                "string.prototype.trimend": "^1.0.1",
+                "string.prototype.trimstart": "^1.0.1"
               }
             }
           }
@@ -9223,9 +9294,9 @@
           "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
           "dev": true,
           "requires": {
-            "regenerate": "1.4.2",
-            "regjsgen": "0.2.0",
-            "regjsparser": "0.1.5"
+            "regenerate": "^1.2.1",
+            "regjsgen": "^0.2.0",
+            "regjsparser": "^0.1.4"
           }
         },
         "regjsgen": {
@@ -9240,7 +9311,7 @@
           "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
           "dev": true,
           "requires": {
-            "jsesc": "0.5.0"
+            "jsesc": "~0.5.0"
           },
           "dependencies": {
             "jsesc": {
@@ -9269,7 +9340,7 @@
           "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
           "dev": true,
           "requires": {
-            "is-finite": "1.1.0"
+            "is-finite": "^1.0.0"
           }
         },
         "request": {
@@ -9278,26 +9349,26 @@
           "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
           "dev": true,
           "requires": {
-            "aws-sign2": "0.7.0",
-            "aws4": "1.11.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.8",
-            "extend": "3.0.2",
-            "forever-agent": "0.6.1",
-            "form-data": "2.3.3",
-            "har-validator": "5.1.5",
-            "http-signature": "1.2.0",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.28",
-            "oauth-sign": "0.9.0",
-            "performance-now": "2.1.0",
-            "qs": "6.5.2",
-            "safe-buffer": "5.2.1",
-            "tough-cookie": "2.5.0",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.4.0"
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.8.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.6",
+            "extend": "~3.0.2",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.2",
+            "har-validator": "~5.1.3",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.19",
+            "oauth-sign": "~0.9.0",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.2",
+            "safe-buffer": "^5.1.2",
+            "tough-cookie": "~2.5.0",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.3.2"
           }
         },
         "resolve-url": {
@@ -9313,7 +9384,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "lowercase-keys": "1.0.1"
+            "lowercase-keys": "^1.0.0"
           }
         },
         "resumer": {
@@ -9322,7 +9393,7 @@
           "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
           "dev": true,
           "requires": {
-            "through": "2.3.8"
+            "through": "~2.3.4"
           }
         },
         "ret": {
@@ -9337,7 +9408,7 @@
           "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
           "dev": true,
           "requires": {
-            "glob": "7.1.3"
+            "glob": "^7.1.3"
           }
         },
         "ripemd160": {
@@ -9346,8 +9417,8 @@
           "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
           "dev": true,
           "requires": {
-            "hash-base": "3.1.0",
-            "inherits": "2.0.4"
+            "hash-base": "^3.0.0",
+            "inherits": "^2.0.1"
           }
         },
         "rlp": {
@@ -9356,7 +9427,7 @@
           "integrity": "sha512-HAfAmL6SDYNWPUOJNrM500x4Thn4PZsEy5pijPh40U9WfNk0z15hUYzO9xVIMAdIHdFtD8CBDHd75Td1g36Mjg==",
           "dev": true,
           "requires": {
-            "bn.js": "4.11.9"
+            "bn.js": "^4.11.1"
           }
         },
         "rustbn.js": {
@@ -9377,7 +9448,7 @@
           "integrity": "sha512-e1wFe99A91XYYxoQbcq2ZJUWurxEyP8vfz7A7vuUe1s95q8r5ebraVaA1BukYJcpM6V16ugWoD9vngi8Ccu5fg==",
           "dev": true,
           "requires": {
-            "events": "3.2.0"
+            "events": "^3.0.0"
           }
         },
         "safe-regex": {
@@ -9386,7 +9457,7 @@
           "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
           "dev": true,
           "requires": {
-            "ret": "0.1.15"
+            "ret": "~0.1.10"
           }
         },
         "safer-buffer": {
@@ -9408,7 +9479,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "pbkdf2": "3.1.1"
+            "pbkdf2": "^3.0.3"
           }
         },
         "secp256k1": {
@@ -9417,9 +9488,9 @@
           "integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
           "dev": true,
           "requires": {
-            "elliptic": "6.5.3",
-            "node-addon-api": "2.0.2",
-            "node-gyp-build": "4.2.3"
+            "elliptic": "^6.5.2",
+            "node-addon-api": "^2.0.0",
+            "node-gyp-build": "^4.2.0"
           }
         },
         "seedrandom": {
@@ -9439,20 +9510,21 @@
           "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
           "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "debug": "2.6.9",
-            "depd": "1.1.2",
-            "destroy": "1.0.4",
-            "encodeurl": "1.0.2",
-            "escape-html": "1.0.3",
-            "etag": "1.8.1",
+            "depd": "~1.1.2",
+            "destroy": "~1.0.4",
+            "encodeurl": "~1.0.2",
+            "escape-html": "~1.0.3",
+            "etag": "~1.8.1",
             "fresh": "0.5.2",
-            "http-errors": "1.7.2",
+            "http-errors": "~1.7.2",
             "mime": "1.6.0",
             "ms": "2.1.1",
-            "on-finished": "2.3.0",
-            "range-parser": "1.2.1",
-            "statuses": "1.5.0"
+            "on-finished": "~2.3.0",
+            "range-parser": "~1.2.1",
+            "statuses": "~1.5.0"
           },
           "dependencies": {
             "debug": {
@@ -9460,6 +9532,7 @@
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
               "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
               "dev": true,
+              "optional": true,
               "requires": {
                 "ms": "2.0.0"
               },
@@ -9468,7 +9541,8 @@
                   "version": "2.0.0",
                   "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
                   "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 }
               }
             },
@@ -9476,7 +9550,8 @@
               "version": "2.1.1",
               "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
               "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -9487,9 +9562,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "encodeurl": "1.0.2",
-            "escape-html": "1.0.3",
-            "parseurl": "1.3.3",
+            "encodeurl": "~1.0.2",
+            "escape-html": "~1.0.3",
+            "parseurl": "~1.3.3",
             "send": "0.17.1"
           }
         },
@@ -9500,11 +9575,11 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "body-parser": "1.19.0",
-            "cors": "2.8.5",
-            "express": "4.17.1",
-            "request": "2.88.2",
-            "xhr": "2.6.0"
+            "body-parser": "^1.16.0",
+            "cors": "^2.8.1",
+            "express": "^4.14.0",
+            "request": "^2.79.0",
+            "xhr": "^2.3.3"
           }
         },
         "set-immediate-shim": {
@@ -9519,10 +9594,10 @@
           "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
           "dev": true,
           "requires": {
-            "extend-shallow": "2.0.1",
-            "is-extendable": "0.1.1",
-            "is-plain-object": "2.0.4",
-            "split-string": "3.1.0"
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.3",
+            "split-string": "^3.0.1"
           },
           "dependencies": {
             "extend-shallow": {
@@ -9531,7 +9606,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             },
             "is-extendable": {
@@ -9552,7 +9627,8 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
           "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "sha.js": {
           "version": "2.4.11",
@@ -9560,25 +9636,27 @@
           "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
           "dev": true,
           "requires": {
-            "inherits": "2.0.4",
-            "safe-buffer": "5.2.1"
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.0.1"
           }
         },
         "simple-concat": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
           "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "simple-get": {
           "version": "2.8.1",
           "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
           "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
           "dev": true,
+          "optional": true,
           "requires": {
-            "decompress-response": "3.3.0",
-            "once": "1.4.0",
-            "simple-concat": "1.0.1"
+            "decompress-response": "^3.3.0",
+            "once": "^1.3.1",
+            "simple-concat": "^1.0.0"
           }
         },
         "snapdragon": {
@@ -9587,14 +9665,14 @@
           "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
           "dev": true,
           "requires": {
-            "base": "0.11.2",
-            "debug": "2.6.9",
-            "define-property": "0.2.5",
-            "extend-shallow": "2.0.1",
-            "map-cache": "0.2.2",
-            "source-map": "0.5.7",
-            "source-map-resolve": "0.5.3",
-            "use": "3.1.1"
+            "base": "^0.11.1",
+            "debug": "^2.2.0",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "map-cache": "^0.2.2",
+            "source-map": "^0.5.6",
+            "source-map-resolve": "^0.5.0",
+            "use": "^3.1.0"
           },
           "dependencies": {
             "debug": {
@@ -9612,7 +9690,7 @@
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "0.1.6"
+                "is-descriptor": "^0.1.0"
               }
             },
             "extend-shallow": {
@@ -9621,7 +9699,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             },
             "is-accessor-descriptor": {
@@ -9630,7 +9708,7 @@
               "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
               "dev": true,
               "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -9639,7 +9717,7 @@
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
-                    "is-buffer": "1.1.6"
+                    "is-buffer": "^1.1.5"
                   }
                 }
               }
@@ -9656,7 +9734,7 @@
               "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
               "dev": true,
               "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -9665,7 +9743,7 @@
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
-                    "is-buffer": "1.1.6"
+                    "is-buffer": "^1.1.5"
                   }
                 }
               }
@@ -9676,9 +9754,9 @@
               "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "0.1.6",
-                "is-data-descriptor": "0.1.4",
-                "kind-of": "5.1.0"
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
               }
             },
             "is-extendable": {
@@ -9707,9 +9785,9 @@
           "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
           "dev": true,
           "requires": {
-            "define-property": "1.0.0",
-            "isobject": "3.0.1",
-            "snapdragon-util": "3.0.1"
+            "define-property": "^1.0.0",
+            "isobject": "^3.0.0",
+            "snapdragon-util": "^3.0.1"
           },
           "dependencies": {
             "define-property": {
@@ -9718,7 +9796,7 @@
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "1.0.2"
+                "is-descriptor": "^1.0.0"
               }
             }
           }
@@ -9729,7 +9807,7 @@
           "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.2.0"
           },
           "dependencies": {
             "is-buffer": {
@@ -9744,7 +9822,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -9761,11 +9839,11 @@
           "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
           "dev": true,
           "requires": {
-            "atob": "2.1.2",
-            "decode-uri-component": "0.2.0",
-            "resolve-url": "0.2.1",
-            "source-map-url": "0.4.0",
-            "urix": "0.1.0"
+            "atob": "^2.1.2",
+            "decode-uri-component": "^0.2.0",
+            "resolve-url": "^0.2.1",
+            "source-map-url": "^0.4.0",
+            "urix": "^0.1.0"
           }
         },
         "source-map-support": {
@@ -9774,8 +9852,8 @@
           "integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
           "dev": true,
           "requires": {
-            "buffer-from": "1.1.1",
-            "source-map": "0.6.1"
+            "buffer-from": "^1.0.0",
+            "source-map": "^0.6.0"
           },
           "dependencies": {
             "source-map": {
@@ -9798,7 +9876,7 @@
           "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
           "dev": true,
           "requires": {
-            "extend-shallow": "3.0.2"
+            "extend-shallow": "^3.0.0"
           }
         },
         "sshpk": {
@@ -9807,15 +9885,15 @@
           "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
           "dev": true,
           "requires": {
-            "asn1": "0.2.4",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.2",
-            "dashdash": "1.14.1",
-            "ecc-jsbn": "0.1.2",
-            "getpass": "0.1.7",
-            "jsbn": "0.1.1",
-            "safer-buffer": "2.1.2",
-            "tweetnacl": "0.14.5"
+            "asn1": "~0.2.3",
+            "assert-plus": "^1.0.0",
+            "bcrypt-pbkdf": "^1.0.0",
+            "dashdash": "^1.12.0",
+            "ecc-jsbn": "~0.1.1",
+            "getpass": "^0.1.1",
+            "jsbn": "~0.1.0",
+            "safer-buffer": "^2.0.2",
+            "tweetnacl": "~0.14.0"
           },
           "dependencies": {
             "tweetnacl": {
@@ -9832,8 +9910,8 @@
           "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
           "dev": true,
           "requires": {
-            "define-property": "0.2.5",
-            "object-copy": "0.1.0"
+            "define-property": "^0.2.5",
+            "object-copy": "^0.1.0"
           },
           "dependencies": {
             "define-property": {
@@ -9842,7 +9920,7 @@
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "0.1.6"
+                "is-descriptor": "^0.1.0"
               }
             },
             "is-accessor-descriptor": {
@@ -9851,7 +9929,7 @@
               "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
               "dev": true,
               "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -9860,7 +9938,7 @@
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
-                    "is-buffer": "1.1.6"
+                    "is-buffer": "^1.1.5"
                   }
                 }
               }
@@ -9877,7 +9955,7 @@
               "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
               "dev": true,
               "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -9886,7 +9964,7 @@
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
-                    "is-buffer": "1.1.6"
+                    "is-buffer": "^1.1.5"
                   }
                 }
               }
@@ -9897,9 +9975,9 @@
               "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "0.1.6",
-                "is-data-descriptor": "0.1.4",
-                "kind-of": "5.1.0"
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
               }
             },
             "kind-of": {
@@ -9914,7 +9992,8 @@
           "version": "1.5.0",
           "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
           "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "stream-to-pull-stream": {
           "version": "1.7.3",
@@ -9922,8 +10001,8 @@
           "integrity": "sha512-6sNyqJpr5dIOQdgNy/xcDWwDuzAsAwVzhzrWlAPAQ7Lkjx/rv0wgvxEyKwTq6FmNd5rjTrELt/CLmaSw7crMGg==",
           "dev": true,
           "requires": {
-            "looper": "3.0.0",
-            "pull-stream": "3.6.14"
+            "looper": "^3.0.0",
+            "pull-stream": "^3.2.3"
           },
           "dependencies": {
             "looper": {
@@ -9938,7 +10017,8 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
           "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "string.prototype.trim": {
           "version": "1.2.3",
@@ -9946,9 +10026,9 @@
           "integrity": "sha512-16IL9pIBA5asNOSukPfxX2W68BaBvxyiRK16H3RA/lWW9BDosh+w7f+LhomPHpXJ82QEe7w7/rY/S1CV97raLg==",
           "dev": true,
           "requires": {
-            "call-bind": "1.0.2",
-            "define-properties": "1.1.3",
-            "es-abstract": "1.18.0-next.1"
+            "call-bind": "^1.0.0",
+            "define-properties": "^1.1.3",
+            "es-abstract": "^1.18.0-next.1"
           }
         },
         "string.prototype.trimend": {
@@ -9957,8 +10037,8 @@
           "integrity": "sha512-ayH0pB+uf0U28CtjlLvL7NaohvR1amUvVZk+y3DYb0Ey2PUV5zPkkKy9+U1ndVEIXO8hNg18eIv9Jntbii+dKw==",
           "dev": true,
           "requires": {
-            "call-bind": "1.0.2",
-            "define-properties": "1.1.3"
+            "call-bind": "^1.0.0",
+            "define-properties": "^1.1.3"
           }
         },
         "string.prototype.trimstart": {
@@ -9967,8 +10047,8 @@
           "integrity": "sha512-oBIBUy5lea5tt0ovtOFiEQaBkoBBkyJhZXzJYrSmDo5IUUqbOPvVezuRs/agBIdZ2p2Eo1FD6bD9USyBLfl3xg==",
           "dev": true,
           "requires": {
-            "call-bind": "1.0.2",
-            "define-properties": "1.1.3"
+            "call-bind": "^1.0.0",
+            "define-properties": "^1.1.3"
           }
         },
         "string_decoder": {
@@ -9977,7 +10057,7 @@
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.2"
+            "safe-buffer": "~5.1.0"
           },
           "dependencies": {
             "safe-buffer": {
@@ -10003,7 +10083,7 @@
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         },
         "swarm-js": {
@@ -10013,17 +10093,17 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "bluebird": "3.7.2",
-            "buffer": "5.7.1",
-            "eth-lib": "0.1.29",
-            "fs-extra": "4.0.3",
-            "got": "7.1.0",
-            "mime-types": "2.1.28",
-            "mkdirp-promise": "5.0.1",
-            "mock-fs": "4.13.0",
-            "setimmediate": "1.0.5",
-            "tar": "4.4.13",
-            "xhr-request": "1.1.0"
+            "bluebird": "^3.5.0",
+            "buffer": "^5.0.5",
+            "eth-lib": "^0.1.26",
+            "fs-extra": "^4.0.2",
+            "got": "^7.1.0",
+            "mime-types": "^2.1.16",
+            "mkdirp-promise": "^5.0.1",
+            "mock-fs": "^4.1.0",
+            "setimmediate": "^1.0.5",
+            "tar": "^4.0.2",
+            "xhr-request": "^1.0.1"
           },
           "dependencies": {
             "fs-extra": {
@@ -10033,9 +10113,9 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "graceful-fs": "4.2.4",
-                "jsonfile": "4.0.0",
-                "universalify": "0.1.2"
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
               }
             },
             "get-stream": {
@@ -10052,20 +10132,20 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "decompress-response": "3.3.0",
-                "duplexer3": "0.1.4",
-                "get-stream": "3.0.0",
-                "is-plain-obj": "1.1.0",
-                "is-retry-allowed": "1.2.0",
-                "is-stream": "1.1.0",
-                "isurl": "1.0.0",
-                "lowercase-keys": "1.0.1",
-                "p-cancelable": "0.3.0",
-                "p-timeout": "1.2.1",
-                "safe-buffer": "5.2.1",
-                "timed-out": "4.0.1",
-                "url-parse-lax": "1.0.0",
-                "url-to-options": "1.0.1"
+                "decompress-response": "^3.2.0",
+                "duplexer3": "^0.1.4",
+                "get-stream": "^3.0.0",
+                "is-plain-obj": "^1.1.0",
+                "is-retry-allowed": "^1.0.0",
+                "is-stream": "^1.0.0",
+                "isurl": "^1.0.0-alpha5",
+                "lowercase-keys": "^1.0.0",
+                "p-cancelable": "^0.3.0",
+                "p-timeout": "^1.1.1",
+                "safe-buffer": "^5.0.1",
+                "timed-out": "^4.0.0",
+                "url-parse-lax": "^1.0.0",
+                "url-to-options": "^1.0.1"
               }
             },
             "is-stream": {
@@ -10096,7 +10176,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "prepend-http": "1.0.4"
+                "prepend-http": "^1.0.1"
               }
             }
           }
@@ -10107,21 +10187,21 @@
           "integrity": "sha512-0/Y20PwRIUkQcTCSi4AASs+OANZZwqPKaipGCEwp10dQMipVvSZwUUCi01Y/OklIGyHKFhIcjock+DKnBfLAFw==",
           "dev": true,
           "requires": {
-            "deep-equal": "1.1.1",
-            "defined": "1.0.0",
-            "dotignore": "0.1.2",
-            "for-each": "0.3.3",
-            "function-bind": "1.1.1",
-            "glob": "7.1.6",
-            "has": "1.0.3",
-            "inherits": "2.0.4",
-            "is-regex": "1.0.5",
-            "minimist": "1.2.5",
-            "object-inspect": "1.7.0",
-            "resolve": "1.17.0",
-            "resumer": "0.0.0",
-            "string.prototype.trim": "1.2.3",
-            "through": "2.3.8"
+            "deep-equal": "~1.1.1",
+            "defined": "~1.0.0",
+            "dotignore": "~0.1.2",
+            "for-each": "~0.3.3",
+            "function-bind": "~1.1.1",
+            "glob": "~7.1.6",
+            "has": "~1.0.3",
+            "inherits": "~2.0.4",
+            "is-regex": "~1.0.5",
+            "minimist": "~1.2.5",
+            "object-inspect": "~1.7.0",
+            "resolve": "~1.17.0",
+            "resumer": "~0.0.0",
+            "string.prototype.trim": "~1.2.1",
+            "through": "~2.3.8"
           },
           "dependencies": {
             "glob": {
@@ -10130,12 +10210,12 @@
               "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
               "dev": true,
               "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.4",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
               }
             },
             "is-regex": {
@@ -10144,7 +10224,7 @@
               "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
               "dev": true,
               "requires": {
-                "has": "1.0.3"
+                "has": "^1.0.3"
               }
             },
             "object-inspect": {
@@ -10159,7 +10239,7 @@
               "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
               "dev": true,
               "requires": {
-                "path-parse": "1.0.6"
+                "path-parse": "^1.0.6"
               }
             }
           }
@@ -10171,13 +10251,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "chownr": "1.1.4",
-            "fs-minipass": "1.2.7",
-            "minipass": "2.9.0",
-            "minizlib": "1.3.3",
-            "mkdirp": "0.5.5",
-            "safe-buffer": "5.2.1",
-            "yallist": "3.1.1"
+            "chownr": "^1.1.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.8.6",
+            "minizlib": "^1.2.1",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.3"
           },
           "dependencies": {
             "fs-minipass": {
@@ -10187,7 +10267,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "minipass": "2.9.0"
+                "minipass": "^2.6.0"
               }
             },
             "minipass": {
@@ -10195,9 +10275,10 @@
               "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
               "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
               "dev": true,
+              "optional": true,
               "requires": {
-                "safe-buffer": "5.2.1",
-                "yallist": "3.1.1"
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.0"
               }
             }
           }
@@ -10214,15 +10295,16 @@
           "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
           "dev": true,
           "requires": {
-            "readable-stream": "2.3.7",
-            "xtend": "4.0.2"
+            "readable-stream": "~2.3.6",
+            "xtend": "~4.0.1"
           }
         },
         "timed-out": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
           "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "tmp": {
           "version": "0.1.0",
@@ -10230,7 +10312,7 @@
           "integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
           "dev": true,
           "requires": {
-            "rimraf": "2.6.3"
+            "rimraf": "^2.6.3"
           }
         },
         "to-object-path": {
@@ -10239,7 +10321,7 @@
           "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "is-buffer": {
@@ -10254,7 +10336,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -10272,17 +10354,18 @@
           "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
           "dev": true,
           "requires": {
-            "define-property": "2.0.2",
-            "extend-shallow": "3.0.2",
-            "regex-not": "1.0.2",
-            "safe-regex": "1.1.0"
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "regex-not": "^1.0.2",
+            "safe-regex": "^1.1.0"
           }
         },
         "toidentifier": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
           "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "tough-cookie": {
           "version": "2.5.0",
@@ -10290,8 +10373,8 @@
           "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
           "dev": true,
           "requires": {
-            "psl": "1.8.0",
-            "punycode": "2.1.1"
+            "psl": "^1.1.28",
+            "punycode": "^2.1.1"
           }
         },
         "trim-right": {
@@ -10306,7 +10389,7 @@
           "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.2.1"
+            "safe-buffer": "^5.0.1"
           }
         },
         "tweetnacl": {
@@ -10332,9 +10415,10 @@
           "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
           "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
           "dev": true,
+          "optional": true,
           "requires": {
             "media-typer": "0.3.0",
-            "mime-types": "2.1.28"
+            "mime-types": "~2.1.24"
           }
         },
         "typedarray": {
@@ -10349,7 +10433,7 @@
           "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
           "dev": true,
           "requires": {
-            "is-typedarray": "1.0.0"
+            "is-typedarray": "^1.0.0"
           }
         },
         "typewise": {
@@ -10358,7 +10442,7 @@
           "integrity": "sha1-EGeTZUCvl5N8xdz5kiSG6fooRlE=",
           "dev": true,
           "requires": {
-            "typewise-core": "1.2.0"
+            "typewise-core": "^1.2.0"
           }
         },
         "typewise-core": {
@@ -10384,7 +10468,8 @@
           "version": "1.9.1",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
           "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "union-value": {
           "version": "1.0.1",
@@ -10392,10 +10477,10 @@
           "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
           "dev": true,
           "requires": {
-            "arr-union": "3.1.0",
-            "get-value": "2.0.6",
-            "is-extendable": "0.1.1",
-            "set-value": "2.0.1"
+            "arr-union": "^3.1.0",
+            "get-value": "^2.0.6",
+            "is-extendable": "^0.1.1",
+            "set-value": "^2.0.1"
           },
           "dependencies": {
             "is-extendable": {
@@ -10422,7 +10507,8 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
           "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "unset-value": {
           "version": "1.0.0",
@@ -10430,8 +10516,8 @@
           "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
           "dev": true,
           "requires": {
-            "has-value": "0.3.1",
-            "isobject": "3.0.1"
+            "has-value": "^0.3.1",
+            "isobject": "^3.0.0"
           },
           "dependencies": {
             "has-value": {
@@ -10440,9 +10526,9 @@
               "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
               "dev": true,
               "requires": {
-                "get-value": "2.0.6",
-                "has-values": "0.1.4",
-                "isobject": "2.1.0"
+                "get-value": "^2.0.3",
+                "has-values": "^0.1.4",
+                "isobject": "^2.0.0"
               },
               "dependencies": {
                 "isobject": {
@@ -10470,7 +10556,7 @@
           "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
           "dev": true,
           "requires": {
-            "punycode": "2.1.1"
+            "punycode": "^2.1.0"
           }
         },
         "urix": {
@@ -10486,14 +10572,15 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "prepend-http": "2.0.0"
+            "prepend-http": "^2.0.0"
           }
         },
         "url-set-query": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/url-set-query/-/url-set-query-1.0.0.tgz",
           "integrity": "sha1-AW6M/Xwg7gXK/neV6JK9BwL6ozk=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "url-to-options": {
           "version": "1.0.1",
@@ -10514,14 +10601,15 @@
           "integrity": "sha512-MEF05cPSq3AwJ2C7B7sHAA6i53vONoZbMGX8My5auEVm6W+dJ2Jd/TZPyGJ5CH42V2XtbI5FD28HeHeqlPzZ3Q==",
           "dev": true,
           "requires": {
-            "node-gyp-build": "4.2.3"
+            "node-gyp-build": "^4.2.0"
           }
         },
         "utf8": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
           "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "util-deprecate": {
           "version": "1.0.2",
@@ -10535,11 +10623,11 @@
           "integrity": "sha512-/s3UsZUrIfa6xDhr7zZhnE9SLQ5RIXyYfiVnMMyMDzOc8WhWN4Nbh36H842OyurKbCDAesZOJaVyvmSl6fhGQw==",
           "dev": true,
           "requires": {
-            "call-bind": "1.0.2",
-            "define-properties": "1.1.3",
-            "for-each": "0.3.3",
-            "has-symbols": "1.0.1",
-            "object.getownpropertydescriptors": "2.1.1"
+            "call-bind": "^1.0.0",
+            "define-properties": "^1.1.3",
+            "for-each": "^0.3.3",
+            "has-symbols": "^1.0.1",
+            "object.getownpropertydescriptors": "^2.1.1"
           }
         },
         "utils-merge": {
@@ -10559,13 +10647,15 @@
           "version": "5.0.2",
           "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
           "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "vary": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
           "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "verror": {
           "version": "1.10.0",
@@ -10573,9 +10663,9 @@
           "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
           "dev": true,
           "requires": {
-            "assert-plus": "1.0.0",
+            "assert-plus": "^1.0.0",
             "core-util-is": "1.0.2",
-            "extsprintf": "1.3.0"
+            "extsprintf": "^1.2.0"
           }
         },
         "web3": {
@@ -10601,9 +10691,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "@types/node": "12.19.12",
+            "@types/node": "^12.12.6",
             "got": "9.6.0",
-            "swarm-js": "0.1.40",
+            "swarm-js": "^0.1.40",
             "underscore": "1.9.1"
           },
           "dependencies": {
@@ -10621,10 +10711,11 @@
           "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.2.11.tgz",
           "integrity": "sha512-CN7MEYOY5ryo5iVleIWRE3a3cZqVaLlIbIzDPsvQRUfzYnvzZQRZBm9Mq+ttDi2STOOzc1MKylspz/o3yq/LjQ==",
           "dev": true,
+          "optional": true,
           "requires": {
-            "@types/bn.js": "4.11.6",
-            "@types/node": "12.19.12",
-            "bignumber.js": "9.0.1",
+            "@types/bn.js": "^4.11.5",
+            "@types/node": "^12.12.6",
+            "bignumber.js": "^9.0.0",
             "web3-core-helpers": "1.2.11",
             "web3-core-method": "1.2.11",
             "web3-core-requestmanager": "1.2.11",
@@ -10635,7 +10726,8 @@
               "version": "12.19.12",
               "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.12.tgz",
               "integrity": "sha512-UwfL2uIU9arX/+/PRcIkT08/iBadGN2z6ExOROA2Dh5mAuWTBj6iJbQX4nekiV5H8cTrEG569LeX+HRco9Cbxw==",
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -10644,6 +10736,7 @@
           "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.2.11.tgz",
           "integrity": "sha512-PEPoAoZd5ME7UfbnCZBdzIerpe74GEvlwT4AjOmHeCVZoIFk7EqvOZDejJHt+feJA6kMVTdd0xzRNN295UhC1A==",
           "dev": true,
+          "optional": true,
           "requires": {
             "underscore": "1.9.1",
             "web3-eth-iban": "1.2.11",
@@ -10655,8 +10748,9 @@
           "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.2.11.tgz",
           "integrity": "sha512-ff0q76Cde94HAxLDZ6DbdmKniYCQVtvuaYh+rtOUMB6kssa5FX0q3vPmixi7NPooFnbKmmZCM6NvXg4IreTPIw==",
           "dev": true,
+          "optional": true,
           "requires": {
-            "@ethersproject/transactions": "5.0.9",
+            "@ethersproject/transactions": "^5.0.0-beta.135",
             "underscore": "1.9.1",
             "web3-core-helpers": "1.2.11",
             "web3-core-promievent": "1.2.11",
@@ -10669,6 +10763,7 @@
           "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.2.11.tgz",
           "integrity": "sha512-il4McoDa/Ox9Agh4kyfQ8Ak/9ABYpnF8poBLL33R/EnxLsJOGQG2nZhkJa3I067hocrPSjEdlPt/0bHXsln4qA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "eventemitter3": "4.0.4"
           }
@@ -10678,6 +10773,7 @@
           "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.2.11.tgz",
           "integrity": "sha512-oFhBtLfOiIbmfl6T6gYjjj9igOvtyxJ+fjS+byRxiwFJyJ5BQOz4/9/17gWR1Cq74paTlI7vDGxYfuvfE/mKvA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "underscore": "1.9.1",
             "web3-core-helpers": "1.2.11",
@@ -10691,6 +10787,7 @@
           "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.2.11.tgz",
           "integrity": "sha512-qEF/OVqkCvQ7MPs1JylIZCZkin0aKK9lDxpAtQ1F8niEDGFqn7DT8E/vzbIa0GsOjL2fZjDhWJsaW+BSoAW1gg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "eventemitter3": "4.0.4",
             "underscore": "1.9.1",
@@ -10724,6 +10821,7 @@
           "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.2.11.tgz",
           "integrity": "sha512-PkRYc0+MjuLSgg03QVWqWlQivJqRwKItKtEpRUaxUAeLE7i/uU39gmzm2keHGcQXo3POXAbOnMqkDvOep89Crg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "@ethersproject/abi": "5.0.0-beta.153",
             "underscore": "1.9.1",
@@ -10739,9 +10837,9 @@
           "requires": {
             "crypto-browserify": "3.12.0",
             "eth-lib": "0.2.8",
-            "ethereumjs-common": "1.5.0",
-            "ethereumjs-tx": "2.1.2",
-            "scrypt-js": "3.0.1",
+            "ethereumjs-common": "^1.3.2",
+            "ethereumjs-tx": "^2.1.1",
+            "scrypt-js": "^3.0.1",
             "underscore": "1.9.1",
             "uuid": "3.3.2",
             "web3-core": "1.2.11",
@@ -10757,9 +10855,9 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "bn.js": "4.11.9",
-                "elliptic": "6.5.3",
-                "xhr-request-promise": "0.1.3"
+                "bn.js": "^4.11.6",
+                "elliptic": "^6.4.0",
+                "xhr-request-promise": "^0.1.2"
               }
             },
             "uuid": {
@@ -10776,8 +10874,9 @@
           "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.2.11.tgz",
           "integrity": "sha512-MzYuI/Rq2o6gn7vCGcnQgco63isPNK5lMAan2E51AJLknjSLnOxwNY3gM8BcKoy4Z+v5Dv00a03Xuk78JowFow==",
           "dev": true,
+          "optional": true,
           "requires": {
-            "@types/bn.js": "4.11.6",
+            "@types/bn.js": "^4.11.5",
             "underscore": "1.9.1",
             "web3-core": "1.2.11",
             "web3-core-helpers": "1.2.11",
@@ -10795,7 +10894,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "content-hash": "2.5.2",
+            "content-hash": "^2.5.2",
             "eth-ens-namehash": "2.0.8",
             "underscore": "1.9.1",
             "web3-core": "1.2.11",
@@ -10811,8 +10910,9 @@
           "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.2.11.tgz",
           "integrity": "sha512-ozuVlZ5jwFC2hJY4+fH9pIcuH1xP0HEFhtWsR69u9uDIANHLPQQtWYmdj7xQ3p2YT4bQLq/axKhZi7EZVetmxQ==",
           "dev": true,
+          "optional": true,
           "requires": {
-            "bn.js": "4.11.9",
+            "bn.js": "^4.11.9",
             "web3-utils": "1.2.11"
           }
         },
@@ -10821,8 +10921,9 @@
           "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.2.11.tgz",
           "integrity": "sha512-42IzUtKq9iHZ8K9VN0vAI50iSU9tOA1V7XU2BhF/tb7We2iKBVdkley2fg26TxlOcKNEHm7o6HRtiiFsVK4Ifw==",
           "dev": true,
+          "optional": true,
           "requires": {
-            "@types/node": "12.19.12",
+            "@types/node": "^12.12.6",
             "web3-core": "1.2.11",
             "web3-core-helpers": "1.2.11",
             "web3-core-method": "1.2.11",
@@ -10834,7 +10935,8 @@
               "version": "12.19.12",
               "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.12.tgz",
               "integrity": "sha512-UwfL2uIU9arX/+/PRcIkT08/iBadGN2z6ExOROA2Dh5mAuWTBj6iJbQX4nekiV5H8cTrEG569LeX+HRco9Cbxw==",
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -10843,6 +10945,7 @@
           "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.2.11.tgz",
           "integrity": "sha512-sjrSDj0pTfZouR5BSTItCuZ5K/oZPVdVciPQ6981PPPIwJJkCMeVjD7I4zO3qDPCnBjBSbWvVnLdwqUBPtHxyg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "web3-core": "1.2.11",
             "web3-core-method": "1.2.11",
@@ -10855,26 +10958,26 @@
           "integrity": "sha512-iSv31h2qXkr9vrL6UZDm4leZMc32SjWJFGOp/D92JXfcEboCqraZyuExDkpxKw8ziTufXieNM7LSXNHzszYdJw==",
           "dev": true,
           "requires": {
-            "async": "2.6.2",
-            "backoff": "2.5.0",
-            "clone": "2.1.2",
-            "cross-fetch": "2.2.3",
-            "eth-block-tracker": "3.0.1",
-            "eth-json-rpc-infura": "3.2.1",
-            "eth-sig-util": "1.4.2",
-            "ethereumjs-block": "1.7.1",
-            "ethereumjs-tx": "1.3.7",
-            "ethereumjs-util": "5.2.1",
-            "ethereumjs-vm": "2.6.0",
-            "json-rpc-error": "2.0.0",
-            "json-stable-stringify": "1.0.1",
-            "promise-to-callback": "1.0.0",
-            "readable-stream": "2.3.7",
-            "request": "2.88.2",
-            "semaphore": "1.1.0",
-            "ws": "5.2.2",
-            "xhr": "2.6.0",
-            "xtend": "4.0.2"
+            "async": "^2.5.0",
+            "backoff": "^2.5.0",
+            "clone": "^2.0.0",
+            "cross-fetch": "^2.1.0",
+            "eth-block-tracker": "^3.0.0",
+            "eth-json-rpc-infura": "^3.1.0",
+            "eth-sig-util": "^1.4.2",
+            "ethereumjs-block": "^1.2.2",
+            "ethereumjs-tx": "^1.2.0",
+            "ethereumjs-util": "^5.1.5",
+            "ethereumjs-vm": "^2.3.4",
+            "json-rpc-error": "^2.0.0",
+            "json-stable-stringify": "^1.0.1",
+            "promise-to-callback": "^1.0.0",
+            "readable-stream": "^2.2.9",
+            "request": "^2.85.0",
+            "semaphore": "^1.0.3",
+            "ws": "^5.1.1",
+            "xhr": "^2.2.0",
+            "xtend": "^4.0.1"
           },
           "dependencies": {
             "abstract-leveldown": {
@@ -10883,7 +10986,7 @@
               "integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
               "dev": true,
               "requires": {
-                "xtend": "4.0.2"
+                "xtend": "~4.0.0"
               }
             },
             "deferred-leveldown": {
@@ -10892,7 +10995,7 @@
               "integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
               "dev": true,
               "requires": {
-                "abstract-leveldown": "2.6.3"
+                "abstract-leveldown": "~2.6.0"
               }
             },
             "eth-sig-util": {
@@ -10901,16 +11004,17 @@
               "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
               "dev": true,
               "requires": {
-                "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#ee3994657fa7a427238e6ba92a84d0b529bbcde0",
-                "ethereumjs-util": "5.2.1"
+                "ethereumjs-abi": "ethereumjs-abi@git+https://github.com/ethereumjs/ethereumjs-abi.git#ee3994657fa7a427238e6ba92a84d0b529bbcde0",
+                "ethereumjs-util": "^5.1.1"
               }
             },
             "ethereumjs-abi": {
               "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#ee3994657fa7a427238e6ba92a84d0b529bbcde0",
+              "from": "ethereumjs-abi@git+https://github.com/ethereumjs/ethereumjs-abi.git#ee3994657fa7a427238e6ba92a84d0b529bbcde0",
               "dev": true,
               "requires": {
-                "bn.js": "4.11.9",
-                "ethereumjs-util": "6.2.1"
+                "bn.js": "^4.11.8",
+                "ethereumjs-util": "^6.0.0"
               },
               "dependencies": {
                 "ethereumjs-util": {
@@ -10919,13 +11023,13 @@
                   "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
                   "dev": true,
                   "requires": {
-                    "@types/bn.js": "4.11.6",
-                    "bn.js": "4.11.9",
-                    "create-hash": "1.2.0",
-                    "elliptic": "6.5.3",
-                    "ethereum-cryptography": "0.1.3",
+                    "@types/bn.js": "^4.11.3",
+                    "bn.js": "^4.11.0",
+                    "create-hash": "^1.1.2",
+                    "elliptic": "^6.5.2",
+                    "ethereum-cryptography": "^0.1.3",
                     "ethjs-util": "0.1.6",
-                    "rlp": "2.2.6"
+                    "rlp": "^2.2.3"
                   }
                 }
               }
@@ -10936,9 +11040,9 @@
               "integrity": "sha512-bgDojnXGjhMwo6eXQC0bY6UK2liSFUSMwwylOmQvZbSl/D7NXQ3+vrGO46ZeOgjGfxXmgIeVNDIiHw7fNZM4VA==",
               "dev": true,
               "requires": {
-                "ethereumjs-util": "5.2.1",
-                "rlp": "2.2.6",
-                "safe-buffer": "5.1.2"
+                "ethereumjs-util": "^5.0.0",
+                "rlp": "^2.0.0",
+                "safe-buffer": "^5.1.1"
               }
             },
             "ethereumjs-block": {
@@ -10947,11 +11051,11 @@
               "integrity": "sha512-B+sSdtqm78fmKkBq78/QLKJbu/4Ts4P2KFISdgcuZUPDm9x+N7qgBPIIFUGbaakQh8bzuquiRVbdmvPKqbILRg==",
               "dev": true,
               "requires": {
-                "async": "2.6.2",
+                "async": "^2.0.1",
                 "ethereum-common": "0.2.0",
-                "ethereumjs-tx": "1.3.7",
-                "ethereumjs-util": "5.2.1",
-                "merkle-patricia-tree": "2.3.2"
+                "ethereumjs-tx": "^1.2.2",
+                "ethereumjs-util": "^5.0.0",
+                "merkle-patricia-tree": "^2.1.2"
               },
               "dependencies": {
                 "ethereum-common": {
@@ -10968,8 +11072,8 @@
               "integrity": "sha512-wvLMxzt1RPhAQ9Yi3/HKZTn0FZYpnsmQdbKYfUUpi4j1SEIcbkd9tndVjcPrufY3V7j2IebOpC00Zp2P/Ay2kA==",
               "dev": true,
               "requires": {
-                "ethereum-common": "0.0.18",
-                "ethereumjs-util": "5.2.1"
+                "ethereum-common": "^0.0.18",
+                "ethereumjs-util": "^5.0.0"
               }
             },
             "ethereumjs-util": {
@@ -10978,13 +11082,13 @@
               "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
               "dev": true,
               "requires": {
-                "bn.js": "4.11.9",
-                "create-hash": "1.2.0",
-                "elliptic": "6.5.3",
-                "ethereum-cryptography": "0.1.3",
-                "ethjs-util": "0.1.6",
-                "rlp": "2.2.6",
-                "safe-buffer": "5.1.2"
+                "bn.js": "^4.11.0",
+                "create-hash": "^1.1.2",
+                "elliptic": "^6.5.2",
+                "ethereum-cryptography": "^0.1.3",
+                "ethjs-util": "^0.1.3",
+                "rlp": "^2.0.0",
+                "safe-buffer": "^5.1.1"
               }
             },
             "ethereumjs-vm": {
@@ -10993,17 +11097,17 @@
               "integrity": "sha512-r/XIUik/ynGbxS3y+mvGnbOKnuLo40V5Mj1J25+HEO63aWYREIqvWeRO/hnROlMBE5WoniQmPmhiaN0ctiHaXw==",
               "dev": true,
               "requires": {
-                "async": "2.6.2",
-                "async-eventemitter": "0.2.4",
-                "ethereumjs-account": "2.0.5",
-                "ethereumjs-block": "2.2.2",
-                "ethereumjs-common": "1.5.0",
-                "ethereumjs-util": "6.2.1",
-                "fake-merkle-patricia-tree": "1.0.1",
-                "functional-red-black-tree": "1.0.1",
-                "merkle-patricia-tree": "2.3.2",
-                "rustbn.js": "0.2.0",
-                "safe-buffer": "5.1.2"
+                "async": "^2.1.2",
+                "async-eventemitter": "^0.2.2",
+                "ethereumjs-account": "^2.0.3",
+                "ethereumjs-block": "~2.2.0",
+                "ethereumjs-common": "^1.1.0",
+                "ethereumjs-util": "^6.0.0",
+                "fake-merkle-patricia-tree": "^1.0.1",
+                "functional-red-black-tree": "^1.0.1",
+                "merkle-patricia-tree": "^2.3.2",
+                "rustbn.js": "~0.2.0",
+                "safe-buffer": "^5.1.1"
               },
               "dependencies": {
                 "ethereumjs-block": {
@@ -11012,11 +11116,11 @@
                   "integrity": "sha512-2p49ifhek3h2zeg/+da6XpdFR3GlqY3BIEiqxGF8j9aSRIgkb7M1Ky+yULBKJOu8PAZxfhsYA+HxUk2aCQp3vg==",
                   "dev": true,
                   "requires": {
-                    "async": "2.6.2",
-                    "ethereumjs-common": "1.5.0",
-                    "ethereumjs-tx": "2.1.2",
-                    "ethereumjs-util": "5.2.1",
-                    "merkle-patricia-tree": "2.3.2"
+                    "async": "^2.0.1",
+                    "ethereumjs-common": "^1.5.0",
+                    "ethereumjs-tx": "^2.1.1",
+                    "ethereumjs-util": "^5.0.0",
+                    "merkle-patricia-tree": "^2.1.2"
                   },
                   "dependencies": {
                     "ethereumjs-util": {
@@ -11025,13 +11129,13 @@
                       "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
                       "dev": true,
                       "requires": {
-                        "bn.js": "4.11.9",
-                        "create-hash": "1.2.0",
-                        "elliptic": "6.5.3",
-                        "ethereum-cryptography": "0.1.3",
-                        "ethjs-util": "0.1.6",
-                        "rlp": "2.2.6",
-                        "safe-buffer": "5.1.2"
+                        "bn.js": "^4.11.0",
+                        "create-hash": "^1.1.2",
+                        "elliptic": "^6.5.2",
+                        "ethereum-cryptography": "^0.1.3",
+                        "ethjs-util": "^0.1.3",
+                        "rlp": "^2.0.0",
+                        "safe-buffer": "^5.1.1"
                       }
                     }
                   }
@@ -11042,8 +11146,8 @@
                   "integrity": "sha512-zZEK1onCeiORb0wyCXUvg94Ve5It/K6GD1K+26KfFKodiBiS6d9lfCXlUKGBBdQ+bv7Day+JK0tj1K+BeNFRAw==",
                   "dev": true,
                   "requires": {
-                    "ethereumjs-common": "1.5.0",
-                    "ethereumjs-util": "6.2.1"
+                    "ethereumjs-common": "^1.5.0",
+                    "ethereumjs-util": "^6.0.0"
                   }
                 },
                 "ethereumjs-util": {
@@ -11052,13 +11156,13 @@
                   "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
                   "dev": true,
                   "requires": {
-                    "@types/bn.js": "4.11.6",
-                    "bn.js": "4.11.9",
-                    "create-hash": "1.2.0",
-                    "elliptic": "6.5.3",
-                    "ethereum-cryptography": "0.1.3",
+                    "@types/bn.js": "^4.11.3",
+                    "bn.js": "^4.11.0",
+                    "create-hash": "^1.1.2",
+                    "elliptic": "^6.5.2",
+                    "ethereum-cryptography": "^0.1.3",
                     "ethjs-util": "0.1.6",
-                    "rlp": "2.2.6"
+                    "rlp": "^2.2.3"
                   }
                 }
               }
@@ -11081,7 +11185,7 @@
               "integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
               "dev": true,
               "requires": {
-                "errno": "0.1.8"
+                "errno": "~0.1.1"
               }
             },
             "level-iterator-stream": {
@@ -11090,10 +11194,10 @@
               "integrity": "sha1-5Dt4sagUPm+pek9IXrjqUwNS8u0=",
               "dev": true,
               "requires": {
-                "inherits": "2.0.4",
-                "level-errors": "1.0.5",
-                "readable-stream": "1.1.14",
-                "xtend": "4.0.2"
+                "inherits": "^2.0.1",
+                "level-errors": "^1.0.3",
+                "readable-stream": "^1.0.33",
+                "xtend": "^4.0.0"
               },
               "dependencies": {
                 "readable-stream": {
@@ -11102,10 +11206,10 @@
                   "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
                   "dev": true,
                   "requires": {
-                    "core-util-is": "1.0.2",
-                    "inherits": "2.0.4",
+                    "core-util-is": "~1.0.0",
+                    "inherits": "~2.0.1",
                     "isarray": "0.0.1",
-                    "string_decoder": "0.10.31"
+                    "string_decoder": "~0.10.x"
                   }
                 }
               }
@@ -11116,8 +11220,8 @@
               "integrity": "sha1-Ny5RIXeSSgBCSwtDrvK7QkltIos=",
               "dev": true,
               "requires": {
-                "readable-stream": "1.0.34",
-                "xtend": "2.1.2"
+                "readable-stream": "~1.0.15",
+                "xtend": "~2.1.1"
               },
               "dependencies": {
                 "readable-stream": {
@@ -11126,10 +11230,10 @@
                   "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                   "dev": true,
                   "requires": {
-                    "core-util-is": "1.0.2",
-                    "inherits": "2.0.4",
+                    "core-util-is": "~1.0.0",
+                    "inherits": "~2.0.1",
                     "isarray": "0.0.1",
-                    "string_decoder": "0.10.31"
+                    "string_decoder": "~0.10.x"
                   }
                 },
                 "xtend": {
@@ -11138,7 +11242,7 @@
                   "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
                   "dev": true,
                   "requires": {
-                    "object-keys": "0.4.0"
+                    "object-keys": "~0.4.0"
                   }
                 }
               }
@@ -11149,13 +11253,13 @@
               "integrity": "sha512-VVGHfKIlmw8w1XqpGOAGwq6sZm2WwWLmlDcULkKWQXEA5EopA8OBNJ2Ck2v6bdk8HeEZSbCSEgzXadyQFm76sQ==",
               "dev": true,
               "requires": {
-                "deferred-leveldown": "1.2.2",
-                "level-codec": "7.0.1",
-                "level-errors": "1.0.5",
-                "level-iterator-stream": "1.3.1",
-                "prr": "1.0.1",
-                "semver": "5.4.1",
-                "xtend": "4.0.2"
+                "deferred-leveldown": "~1.2.1",
+                "level-codec": "~7.0.0",
+                "level-errors": "~1.0.3",
+                "level-iterator-stream": "~1.3.0",
+                "prr": "~1.0.1",
+                "semver": "~5.4.1",
+                "xtend": "~4.0.0"
               }
             },
             "ltgt": {
@@ -11170,12 +11274,12 @@
               "integrity": "sha1-tOThkhdGZP+65BNhqlAPMRnv4hU=",
               "dev": true,
               "requires": {
-                "abstract-leveldown": "2.7.2",
-                "functional-red-black-tree": "1.0.1",
-                "immediate": "3.2.3",
-                "inherits": "2.0.4",
-                "ltgt": "2.2.1",
-                "safe-buffer": "5.1.2"
+                "abstract-leveldown": "~2.7.1",
+                "functional-red-black-tree": "^1.0.1",
+                "immediate": "^3.2.3",
+                "inherits": "~2.0.1",
+                "ltgt": "~2.2.0",
+                "safe-buffer": "~5.1.1"
               },
               "dependencies": {
                 "abstract-leveldown": {
@@ -11184,7 +11288,7 @@
                   "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
                   "dev": true,
                   "requires": {
-                    "xtend": "4.0.2"
+                    "xtend": "~4.0.0"
                   }
                 }
               }
@@ -11195,14 +11299,14 @@
               "integrity": "sha512-81PW5m8oz/pz3GvsAwbauj7Y00rqm81Tzad77tHBwU7pIAtN+TJnMSOJhxBKflSVYhptMMb9RskhqHqrSm1V+g==",
               "dev": true,
               "requires": {
-                "async": "1.5.2",
-                "ethereumjs-util": "5.2.1",
+                "async": "^1.4.2",
+                "ethereumjs-util": "^5.0.0",
                 "level-ws": "0.0.0",
-                "levelup": "1.3.9",
-                "memdown": "1.4.1",
-                "readable-stream": "2.3.7",
-                "rlp": "2.2.6",
-                "semaphore": "1.1.0"
+                "levelup": "^1.2.1",
+                "memdown": "^1.0.0",
+                "readable-stream": "^2.0.0",
+                "rlp": "^2.0.0",
+                "semaphore": ">=1.0.1"
               },
               "dependencies": {
                 "async": {
@@ -11243,7 +11347,7 @@
               "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
               "dev": true,
               "requires": {
-                "async-limiter": "1.0.1"
+                "async-limiter": "~1.0.0"
               }
             }
           }
@@ -11253,6 +11357,7 @@
           "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.2.11.tgz",
           "integrity": "sha512-psh4hYGb1+ijWywfwpB2cvvOIMISlR44F/rJtYkRmQ5jMvG4FOCPlQJPiHQZo+2cc3HbktvvSJzIhkWQJdmvrA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "web3-core-helpers": "1.2.11",
             "xhr2-cookies": "1.1.0"
@@ -11263,6 +11368,7 @@
           "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.2.11.tgz",
           "integrity": "sha512-yhc7Y/k8hBV/KlELxynWjJDzmgDEDjIjBzXK+e0rHBsYEhdCNdIH5Psa456c+l0qTEU2YzycF8VAjYpWfPnBpQ==",
           "dev": true,
+          "optional": true,
           "requires": {
             "oboe": "2.1.4",
             "underscore": "1.9.1",
@@ -11274,11 +11380,12 @@
           "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.2.11.tgz",
           "integrity": "sha512-ZxnjIY1Er8Ty+cE4migzr43zA/+72AF1myzsLaU5eVgdsfV7Jqx7Dix1hbevNZDKFlSoEyq/3j/jYalh3So1Zg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "eventemitter3": "4.0.4",
             "underscore": "1.9.1",
             "web3-core-helpers": "1.2.11",
-            "websocket": "1.0.32"
+            "websocket": "^1.0.31"
           }
         },
         "web3-shh": {
@@ -11299,13 +11406,14 @@
           "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.11.tgz",
           "integrity": "sha512-3Tq09izhD+ThqHEaWYX4VOT7dNPdZiO+c/1QMA0s5X2lDFKK/xHJb7cyTRRVzN2LvlHbR7baS1tmQhSua51TcQ==",
           "dev": true,
+          "optional": true,
           "requires": {
-            "bn.js": "4.11.9",
+            "bn.js": "^4.11.9",
             "eth-lib": "0.2.8",
-            "ethereum-bloom-filters": "1.0.7",
+            "ethereum-bloom-filters": "^1.0.6",
             "ethjs-unit": "0.1.6",
             "number-to-bn": "1.7.0",
-            "randombytes": "2.1.0",
+            "randombytes": "^2.1.0",
             "underscore": "1.9.1",
             "utf8": "3.0.0"
           },
@@ -11315,10 +11423,11 @@
               "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
               "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
               "dev": true,
+              "optional": true,
               "requires": {
-                "bn.js": "4.11.9",
-                "elliptic": "6.5.3",
-                "xhr-request-promise": "0.1.3"
+                "bn.js": "^4.11.6",
+                "elliptic": "^6.4.0",
+                "xhr-request-promise": "^0.1.2"
               }
             }
           }
@@ -11329,12 +11438,12 @@
           "integrity": "sha512-i4yhcllSP4wrpoPMU2N0TQ/q0O94LRG/eUQjEAamRltjQ1oT1PFFKOG4i877OlJgCG8rw6LrrowJp+TYCEWF7Q==",
           "dev": true,
           "requires": {
-            "bufferutil": "4.0.3",
-            "debug": "2.6.9",
-            "es5-ext": "0.10.53",
-            "typedarray-to-buffer": "3.1.5",
-            "utf-8-validate": "5.0.4",
-            "yaeti": "0.0.6"
+            "bufferutil": "^4.0.1",
+            "debug": "^2.2.0",
+            "es5-ext": "^0.10.50",
+            "typedarray-to-buffer": "^3.1.5",
+            "utf-8-validate": "^5.0.2",
+            "yaeti": "^0.0.6"
           },
           "dependencies": {
             "debug": {
@@ -11373,9 +11482,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "async-limiter": "1.0.1",
-            "safe-buffer": "5.1.2",
-            "ultron": "1.1.1"
+            "async-limiter": "~1.0.0",
+            "safe-buffer": "~5.1.0",
+            "ultron": "~1.1.0"
           },
           "dependencies": {
             "safe-buffer": {
@@ -11393,10 +11502,10 @@
           "integrity": "sha512-/eCGLb5rxjx5e3mF1A7s+pLlR6CGyqWN91fv1JgER5mVWg1MZmlhBvy9kjcsOdRk8RrIujotWyJamfyrp+WIcA==",
           "dev": true,
           "requires": {
-            "global": "4.4.0",
-            "is-function": "1.0.2",
-            "parse-headers": "2.0.3",
-            "xtend": "4.0.2"
+            "global": "~4.4.0",
+            "is-function": "^1.0.1",
+            "parse-headers": "^2.0.0",
+            "xtend": "^4.0.0"
           }
         },
         "xhr-request": {
@@ -11404,14 +11513,15 @@
           "resolved": "https://registry.npmjs.org/xhr-request/-/xhr-request-1.1.0.tgz",
           "integrity": "sha512-Y7qzEaR3FDtL3fP30k9wO/e+FBnBByZeybKOhASsGP30NIkRAAkKD/sCnLvgEfAIEC1rcmK7YG8f4oEnIrrWzA==",
           "dev": true,
+          "optional": true,
           "requires": {
-            "buffer-to-arraybuffer": "0.0.5",
-            "object-assign": "4.1.1",
-            "query-string": "5.1.1",
-            "simple-get": "2.8.1",
-            "timed-out": "4.0.1",
-            "url-set-query": "1.0.0",
-            "xhr": "2.6.0"
+            "buffer-to-arraybuffer": "^0.0.5",
+            "object-assign": "^4.1.1",
+            "query-string": "^5.0.1",
+            "simple-get": "^2.7.0",
+            "timed-out": "^4.0.1",
+            "url-set-query": "^1.0.0",
+            "xhr": "^2.0.4"
           }
         },
         "xhr-request-promise": {
@@ -11419,8 +11529,9 @@
           "resolved": "https://registry.npmjs.org/xhr-request-promise/-/xhr-request-promise-0.1.3.tgz",
           "integrity": "sha512-YUBytBsuwgitWtdRzXDDkWAXzhdGB8bYm0sSzMPZT7Z2MBjMSTHFsyCT1yCRATY+XC69DUrQraRAEgcoCRaIPg==",
           "dev": true,
+          "optional": true,
           "requires": {
-            "xhr-request": "1.1.0"
+            "xhr-request": "^1.1.0"
           }
         },
         "xhr2-cookies": {
@@ -11428,8 +11539,9 @@
           "resolved": "https://registry.npmjs.org/xhr2-cookies/-/xhr2-cookies-1.1.0.tgz",
           "integrity": "sha1-fXdEnQmZGX8VXLc7I99yUF7YnUg=",
           "dev": true,
+          "optional": true,
           "requires": {
-            "cookiejar": "2.1.2"
+            "cookiejar": "^2.1.1"
           }
         },
         "xtend": {
@@ -11470,9 +11582,9 @@
       "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
       "dev": true,
       "requires": {
-        "function-bind": "1.1.1",
-        "has": "1.0.3",
-        "has-symbols": "1.0.2"
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
       }
     },
     "get-port": {
@@ -11487,7 +11599,7 @@
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "glob": {
@@ -11496,12 +11608,12 @@
       "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.4",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "glob-parent": {
@@ -11510,7 +11622,7 @@
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
       "requires": {
-        "is-glob": "4.0.1"
+        "is-glob": "^4.0.1"
       }
     },
     "global": {
@@ -11519,8 +11631,8 @@
       "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
       "dev": true,
       "requires": {
-        "min-document": "2.19.0",
-        "process": "0.11.10"
+        "min-document": "^2.19.0",
+        "process": "^0.11.10"
       }
     },
     "graceful-fs": {
@@ -11547,8 +11659,8 @@
       "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
       "dev": true,
       "requires": {
-        "ajv": "6.12.6",
-        "har-schema": "2.0.0"
+        "ajv": "^6.12.3",
+        "har-schema": "^2.0.0"
       }
     },
     "hardhat": {
@@ -11557,53 +11669,53 @@
       "integrity": "sha512-83kCYIrkRq+vrsjOLIv349fbMpL7Vp/ZGpWtu+KLMH3wcAAs+aMsABZJ8W5hb5uo69+06KeF0pCHQ6y8tBAcwA==",
       "dev": true,
       "requires": {
-        "@ethereumjs/block": "3.4.0",
-        "@ethereumjs/blockchain": "5.4.0",
-        "@ethereumjs/common": "2.4.0",
-        "@ethereumjs/tx": "3.3.0",
-        "@ethereumjs/vm": "5.5.2",
-        "@ethersproject/abi": "5.4.1",
-        "@sentry/node": "5.30.0",
-        "@solidity-parser/parser": "0.11.1",
-        "@types/bn.js": "5.1.0",
-        "@types/lru-cache": "5.1.1",
-        "abort-controller": "3.0.0",
-        "adm-zip": "0.4.16",
-        "ansi-escapes": "4.3.2",
-        "chalk": "2.4.2",
-        "chokidar": "3.5.2",
-        "ci-info": "2.0.0",
-        "debug": "4.3.2",
-        "enquirer": "2.3.6",
-        "env-paths": "2.2.1",
-        "eth-sig-util": "2.5.4",
-        "ethereum-cryptography": "0.1.3",
-        "ethereumjs-abi": "0.6.8",
-        "ethereumjs-util": "7.1.0",
-        "find-up": "2.1.0",
+        "@ethereumjs/block": "^3.4.0",
+        "@ethereumjs/blockchain": "^5.4.0",
+        "@ethereumjs/common": "^2.4.0",
+        "@ethereumjs/tx": "^3.3.0",
+        "@ethereumjs/vm": "^5.5.2",
+        "@ethersproject/abi": "^5.1.2",
+        "@sentry/node": "^5.18.1",
+        "@solidity-parser/parser": "^0.11.0",
+        "@types/bn.js": "^5.1.0",
+        "@types/lru-cache": "^5.1.0",
+        "abort-controller": "^3.0.0",
+        "adm-zip": "^0.4.16",
+        "ansi-escapes": "^4.3.0",
+        "chalk": "^2.4.2",
+        "chokidar": "^3.4.0",
+        "ci-info": "^2.0.0",
+        "debug": "^4.1.1",
+        "enquirer": "^2.3.0",
+        "env-paths": "^2.2.0",
+        "eth-sig-util": "^2.5.2",
+        "ethereum-cryptography": "^0.1.2",
+        "ethereumjs-abi": "^0.6.8",
+        "ethereumjs-util": "^7.1.0",
+        "find-up": "^2.1.0",
         "fp-ts": "1.19.3",
-        "fs-extra": "7.0.1",
-        "glob": "7.1.7",
-        "https-proxy-agent": "5.0.0",
-        "immutable": "4.0.0-rc.14",
+        "fs-extra": "^7.0.1",
+        "glob": "^7.1.3",
+        "https-proxy-agent": "^5.0.0",
+        "immutable": "^4.0.0-rc.12",
         "io-ts": "1.10.4",
-        "lodash": "4.17.21",
-        "merkle-patricia-tree": "4.2.1",
-        "mnemonist": "0.38.3",
-        "mocha": "7.2.0",
-        "node-fetch": "2.6.1",
-        "qs": "6.10.1",
-        "raw-body": "2.4.1",
+        "lodash": "^4.17.11",
+        "merkle-patricia-tree": "^4.2.0",
+        "mnemonist": "^0.38.0",
+        "mocha": "^7.1.2",
+        "node-fetch": "^2.6.0",
+        "qs": "^6.7.0",
+        "raw-body": "^2.4.1",
         "resolve": "1.17.0",
-        "semver": "6.3.0",
-        "slash": "3.0.0",
+        "semver": "^6.3.0",
+        "slash": "^3.0.0",
         "solc": "0.7.3",
-        "source-map-support": "0.5.19",
-        "stacktrace-parser": "0.1.10",
-        "true-case-path": "2.2.1",
+        "source-map-support": "^0.5.13",
+        "stacktrace-parser": "^0.1.10",
+        "true-case-path": "^2.2.1",
         "tsort": "0.0.1",
-        "uuid": "3.4.0",
-        "ws": "7.4.6"
+        "uuid": "^3.3.2",
+        "ws": "^7.4.6"
       },
       "dependencies": {
         "find-up": {
@@ -11612,7 +11724,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "2.0.0"
+            "locate-path": "^2.0.0"
           }
         },
         "js-sha3": {
@@ -11627,7 +11739,7 @@
           "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.2.8"
+            "graceful-fs": "^4.1.6"
           }
         },
         "qs": {
@@ -11636,7 +11748,7 @@
           "integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
           "dev": true,
           "requires": {
-            "side-channel": "1.0.4"
+            "side-channel": "^1.0.4"
           }
         },
         "require-from-string": {
@@ -11651,7 +11763,7 @@
           "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
           "dev": true,
           "requires": {
-            "path-parse": "1.0.7"
+            "path-parse": "^1.0.6"
           }
         },
         "slash": {
@@ -11666,14 +11778,14 @@
           "integrity": "sha512-GAsWNAjGzIDg7VxzP6mPjdurby3IkGCjQcM8GFYZT6RyaoUZKmMU6Y7YwG+tFGhv7dwZ8rmR4iwFDrrD99JwqA==",
           "dev": true,
           "requires": {
-            "command-exists": "1.2.9",
+            "command-exists": "^1.2.8",
             "commander": "3.0.2",
-            "follow-redirects": "1.14.3",
-            "fs-extra": "0.30.0",
+            "follow-redirects": "^1.12.1",
+            "fs-extra": "^0.30.0",
             "js-sha3": "0.8.0",
-            "memorystream": "0.3.1",
-            "require-from-string": "2.0.2",
-            "semver": "5.7.1",
+            "memorystream": "^0.3.1",
+            "require-from-string": "^2.0.0",
+            "semver": "^5.5.0",
             "tmp": "0.0.33"
           },
           "dependencies": {
@@ -11683,11 +11795,11 @@
               "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
               "dev": true,
               "requires": {
-                "graceful-fs": "4.2.8",
-                "jsonfile": "2.4.0",
-                "klaw": "1.3.1",
-                "path-is-absolute": "1.0.1",
-                "rimraf": "2.7.1"
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^2.1.0",
+                "klaw": "^1.0.0",
+                "path-is-absolute": "^1.0.0",
+                "rimraf": "^2.2.8"
               }
             },
             "semver": {
@@ -11712,8 +11824,8 @@
       "integrity": "sha512-G376zKh81G3K9WtDA+SoTLWsoygikH++tD1E7llx+X7J+GbIqfwhDKKgvJjcnEesMrtR9UqQHK02lJuXY1RTxw==",
       "dev": true,
       "requires": {
-        "eth-gas-reporter": "0.2.22",
-        "sha1": "1.1.1"
+        "eth-gas-reporter": "^0.2.20",
+        "sha1": "^1.1.1"
       }
     },
     "hardhat-typechain": {
@@ -11728,7 +11840,7 @@
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "dev": true,
       "requires": {
-        "function-bind": "1.1.1"
+        "function-bind": "^1.1.1"
       }
     },
     "has-bigints": {
@@ -11755,7 +11867,7 @@
       "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
       "dev": true,
       "requires": {
-        "has-symbols": "1.0.2"
+        "has-symbols": "^1.0.2"
       }
     },
     "hash-base": {
@@ -11764,9 +11876,9 @@
       "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.4",
-        "readable-stream": "3.6.0",
-        "safe-buffer": "5.2.1"
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.6.0",
+        "safe-buffer": "^5.2.0"
       }
     },
     "hash.js": {
@@ -11775,8 +11887,8 @@
       "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.4",
-        "minimalistic-assert": "1.0.1"
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
       }
     },
     "he": {
@@ -11791,9 +11903,9 @@
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
       "dev": true,
       "requires": {
-        "hash.js": "1.1.7",
-        "minimalistic-assert": "1.0.1",
-        "minimalistic-crypto-utils": "1.0.1"
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
       }
     },
     "hosted-git-info": {
@@ -11808,10 +11920,10 @@
       "integrity": "sha512-/EcDMwJZh3mABI2NhGfHOGOeOZITqfkEO4p/xK+l3NpyncIHUQBoMvCSF/b5GqvKtySC2srL/GGG3+EtlqlmCw==",
       "dev": true,
       "requires": {
-        "caseless": "0.12.0",
-        "concat-stream": "1.6.2",
-        "http-response-object": "3.0.2",
-        "parse-cache-control": "1.0.1"
+        "caseless": "^0.12.0",
+        "concat-stream": "^1.6.2",
+        "http-response-object": "^3.0.1",
+        "parse-cache-control": "^1.0.1"
       }
     },
     "http-errors": {
@@ -11820,10 +11932,10 @@
       "integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
       "dev": true,
       "requires": {
-        "depd": "1.1.2",
+        "depd": "~1.1.2",
         "inherits": "2.0.4",
         "setprototypeof": "1.1.1",
-        "statuses": "1.5.0",
+        "statuses": ">= 1.5.0 < 2",
         "toidentifier": "1.0.0"
       }
     },
@@ -11833,7 +11945,7 @@
       "integrity": "sha512-bqX0XTF6fnXSQcEJ2Iuyr75yVakyjIDCqroJQ/aHfSdlM743Cwqoi2nDYMzLGWUcuTWGWy8AAvOKXTfiv6q9RA==",
       "dev": true,
       "requires": {
-        "@types/node": "10.17.60"
+        "@types/node": "^10.0.3"
       },
       "dependencies": {
         "@types/node": {
@@ -11850,9 +11962,9 @@
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.16.1"
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "https-proxy-agent": {
@@ -11861,8 +11973,8 @@
       "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
       "dev": true,
       "requires": {
-        "agent-base": "6.0.2",
-        "debug": "4.3.2"
+        "agent-base": "6",
+        "debug": "4"
       }
     },
     "iconv-lite": {
@@ -11871,7 +11983,7 @@
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "dev": true,
       "requires": {
-        "safer-buffer": "2.1.2"
+        "safer-buffer": ">= 2.1.2 < 3"
       }
     },
     "idna-uts46-hx": {
@@ -11907,8 +12019,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -11923,9 +12035,9 @@
       "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
       "dev": true,
       "requires": {
-        "get-intrinsic": "1.1.1",
-        "has": "1.0.3",
-        "side-channel": "1.0.4"
+        "get-intrinsic": "^1.1.0",
+        "has": "^1.0.3",
+        "side-channel": "^1.0.4"
       }
     },
     "invert-kv": {
@@ -11940,7 +12052,7 @@
       "integrity": "sha512-b23PteSnYXSONJ6JQXRAlvJhuw8KOtkqa87W4wDtvMrud/DTJd5X+NpOOI+O/zZwVq6v0VLAaJ+1EDViKEuN9g==",
       "dev": true,
       "requires": {
-        "fp-ts": "1.19.3"
+        "fp-ts": "^1.0.0"
       }
     },
     "is-arrayish": {
@@ -11955,7 +12067,7 @@
       "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
       "dev": true,
       "requires": {
-        "has-bigints": "1.0.1"
+        "has-bigints": "^1.0.1"
       }
     },
     "is-binary-path": {
@@ -11964,7 +12076,7 @@
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
       "dev": true,
       "requires": {
-        "binary-extensions": "2.2.0"
+        "binary-extensions": "^2.0.0"
       }
     },
     "is-boolean-object": {
@@ -11973,8 +12085,8 @@
       "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
       "dev": true,
       "requires": {
-        "call-bind": "1.0.2",
-        "has-tostringtag": "1.0.0"
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
       }
     },
     "is-buffer": {
@@ -11995,7 +12107,7 @@
       "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
       "dev": true,
       "requires": {
-        "ci-info": "2.0.0"
+        "ci-info": "^2.0.0"
       }
     },
     "is-core-module": {
@@ -12004,7 +12116,7 @@
       "integrity": "sha512-wShG8vs60jKfPWpF2KZRaAtvt3a20OAn7+IJ6hLPECpSABLcKtFKTTI4ZtH5QcBruBHlq+WsdHWyz0BCZW7svQ==",
       "dev": true,
       "requires": {
-        "has": "1.0.3"
+        "has": "^1.0.3"
       }
     },
     "is-date-object": {
@@ -12013,7 +12125,7 @@
       "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
       "dev": true,
       "requires": {
-        "has-tostringtag": "1.0.0"
+        "has-tostringtag": "^1.0.0"
       }
     },
     "is-docker": {
@@ -12034,7 +12146,7 @@
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "dev": true,
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-function": {
@@ -12049,7 +12161,7 @@
       "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
       "dev": true,
       "requires": {
-        "is-extglob": "2.1.1"
+        "is-extglob": "^2.1.1"
       }
     },
     "is-hex-prefixed": {
@@ -12076,7 +12188,7 @@
       "integrity": "sha512-bEVOqiRcvo3zO1+G2lVMy+gkkEm9Yh7cDMRusKKu5ZJKPUYSJwICTKZrNKHA2EbSP0Tu0+6B/emsYNHZyn6K8g==",
       "dev": true,
       "requires": {
-        "has-tostringtag": "1.0.0"
+        "has-tostringtag": "^1.0.0"
       }
     },
     "is-regex": {
@@ -12085,8 +12197,8 @@
       "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
       "dev": true,
       "requires": {
-        "call-bind": "1.0.2",
-        "has-tostringtag": "1.0.0"
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
       }
     },
     "is-string": {
@@ -12095,7 +12207,7 @@
       "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
       "dev": true,
       "requires": {
-        "has-tostringtag": "1.0.0"
+        "has-tostringtag": "^1.0.0"
       }
     },
     "is-symbol": {
@@ -12104,7 +12216,7 @@
       "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
       "dev": true,
       "requires": {
-        "has-symbols": "1.0.2"
+        "has-symbols": "^1.0.2"
       }
     },
     "is-typedarray": {
@@ -12131,7 +12243,7 @@
       "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
       "dev": true,
       "requires": {
-        "is-docker": "2.2.1"
+        "is-docker": "^2.0.0"
       }
     },
     "isarray": {
@@ -12164,8 +12276,8 @@
       "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "dev": true,
       "requires": {
-        "argparse": "1.0.10",
-        "esprima": "4.0.1"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       }
     },
     "jsbn": {
@@ -12198,7 +12310,7 @@
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.2.8"
+        "graceful-fs": "^4.1.6"
       }
     },
     "jsprim": {
@@ -12219,9 +12331,9 @@
       "integrity": "sha512-PyKKjkH53wDMLGrvmRGSNWgmSxZOUqbnXwKL9tmgbFYA1iAYqW21kfR7mZXV0MlESiefxQQE9X9fTa3X+2MPDQ==",
       "dev": true,
       "requires": {
-        "node-addon-api": "2.0.2",
-        "node-gyp-build": "4.2.3",
-        "readable-stream": "3.6.0"
+        "node-addon-api": "^2.0.0",
+        "node-gyp-build": "^4.2.0",
+        "readable-stream": "^3.6.0"
       }
     },
     "klaw": {
@@ -12230,7 +12342,7 @@
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.2.8"
+        "graceful-fs": "^4.1.9"
       }
     },
     "klaw-sync": {
@@ -12239,7 +12351,7 @@
       "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.2.8"
+        "graceful-fs": "^4.1.11"
       }
     },
     "lcid": {
@@ -12248,7 +12360,7 @@
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "dev": true,
       "requires": {
-        "invert-kv": "1.0.0"
+        "invert-kv": "^1.0.0"
       }
     },
     "level-codec": {
@@ -12257,7 +12369,7 @@
       "integrity": "sha512-UyIwNb1lJBChJnGfjmO0OR+ezh2iVu1Kas3nvBS/BzGnx79dv6g7unpKIDNPMhfdTEGoc7mC8uAu51XEtX+FHQ==",
       "dev": true,
       "requires": {
-        "buffer": "5.7.1"
+        "buffer": "^5.6.0"
       }
     },
     "level-concat-iterator": {
@@ -12272,7 +12384,7 @@
       "integrity": "sha512-UVprBJXite4gPS+3VznfgDSU8PTRuVX0NXwoWW50KLxd2yw4Y1t2JUR5In1itQnudZqRMT9DlAM3Q//9NCjCFw==",
       "dev": true,
       "requires": {
-        "errno": "0.1.8"
+        "errno": "~0.1.1"
       }
     },
     "level-iterator-stream": {
@@ -12281,9 +12393,9 @@
       "integrity": "sha512-ZSthfEqzGSOMWoUGhTXdX9jv26d32XJuHz/5YnuHZzH6wldfWMOVwI9TBtKcya4BKTyTt3XVA0A3cF3q5CY30Q==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.4",
-        "readable-stream": "3.6.0",
-        "xtend": "4.0.2"
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0",
+        "xtend": "^4.0.2"
       }
     },
     "level-mem": {
@@ -12292,8 +12404,8 @@
       "integrity": "sha512-qd+qUJHXsGSFoHTziptAKXoLX87QjR7v2KMbqncDXPxQuCdsQlzmyX+gwrEHhlzn08vkf8TyipYyMmiC6Gobzg==",
       "dev": true,
       "requires": {
-        "level-packager": "5.1.1",
-        "memdown": "5.1.0"
+        "level-packager": "^5.0.3",
+        "memdown": "^5.0.0"
       }
     },
     "level-packager": {
@@ -12302,8 +12414,8 @@
       "integrity": "sha512-HMwMaQPlTC1IlcwT3+swhqf/NUO+ZhXVz6TY1zZIIZlIR0YSn8GtAAWmIvKjNY16ZkEg/JcpAuQskxsXqC0yOQ==",
       "dev": true,
       "requires": {
-        "encoding-down": "6.3.0",
-        "levelup": "4.4.0"
+        "encoding-down": "^6.3.0",
+        "levelup": "^4.3.2"
       }
     },
     "level-supports": {
@@ -12312,7 +12424,7 @@
       "integrity": "sha512-rXM7GYnW8gsl1vedTJIbzOrRv85c/2uCMpiiCzO2fndd06U/kUXEEU9evYn4zFggBOg36IsBW8LzqIpETwwQzg==",
       "dev": true,
       "requires": {
-        "xtend": "4.0.2"
+        "xtend": "^4.0.2"
       }
     },
     "level-ws": {
@@ -12321,9 +12433,9 @@
       "integrity": "sha512-1iv7VXx0G9ec1isqQZ7y5LmoZo/ewAsyDHNA8EFDW5hqH2Kqovm33nSFkSdnLLAK+I5FlT+lo5Cw9itGe+CpQA==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.4",
-        "readable-stream": "3.6.0",
-        "xtend": "4.0.2"
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.0",
+        "xtend": "^4.0.1"
       }
     },
     "levelup": {
@@ -12332,11 +12444,11 @@
       "integrity": "sha512-94++VFO3qN95cM/d6eBXvd894oJE0w3cInq9USsyQzzoJxmiYzPAocNcuGCPGGjoXqDVJcr3C1jzt1TSjyaiLQ==",
       "dev": true,
       "requires": {
-        "deferred-leveldown": "5.3.0",
-        "level-errors": "2.0.1",
-        "level-iterator-stream": "4.0.2",
-        "level-supports": "1.0.1",
-        "xtend": "4.0.2"
+        "deferred-leveldown": "~5.3.0",
+        "level-errors": "~2.0.0",
+        "level-iterator-stream": "~4.0.0",
+        "level-supports": "~1.0.0",
+        "xtend": "~4.0.0"
       }
     },
     "load-json-file": {
@@ -12345,11 +12457,11 @@
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.2.8",
-        "parse-json": "2.2.0",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "strip-bom": "2.0.0"
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "strip-bom": "^2.0.0"
       }
     },
     "locate-path": {
@@ -12358,8 +12470,8 @@
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "dev": true,
       "requires": {
-        "p-locate": "2.0.0",
-        "path-exists": "3.0.0"
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
       },
       "dependencies": {
         "path-exists": {
@@ -12388,7 +12500,7 @@
       "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
       "dev": true,
       "requires": {
-        "chalk": "2.4.2"
+        "chalk": "^2.4.2"
       }
     },
     "lru-cache": {
@@ -12397,7 +12509,7 @@
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dev": true,
       "requires": {
-        "yallist": "3.1.1"
+        "yallist": "^3.0.2"
       }
     },
     "lru_map": {
@@ -12436,9 +12548,9 @@
       "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
       "dev": true,
       "requires": {
-        "hash-base": "3.1.0",
-        "inherits": "2.0.4",
-        "safe-buffer": "5.2.1"
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
       }
     },
     "memdown": {
@@ -12447,12 +12559,12 @@
       "integrity": "sha512-B3J+UizMRAlEArDjWHTMmadet+UKwHd3UjMgGBkZcKAxAYVPS9o0Yeiha4qvz7iGiL2Sb3igUft6p7nbFWctpw==",
       "dev": true,
       "requires": {
-        "abstract-leveldown": "6.2.3",
-        "functional-red-black-tree": "1.0.1",
-        "immediate": "3.2.3",
-        "inherits": "2.0.4",
-        "ltgt": "2.2.1",
-        "safe-buffer": "5.2.1"
+        "abstract-leveldown": "~6.2.1",
+        "functional-red-black-tree": "~1.0.1",
+        "immediate": "~3.2.3",
+        "inherits": "~2.0.1",
+        "ltgt": "~2.2.0",
+        "safe-buffer": "~5.2.0"
       },
       "dependencies": {
         "abstract-leveldown": {
@@ -12461,11 +12573,11 @@
           "integrity": "sha512-BsLm5vFMRUrrLeCcRc+G0t2qOaTzpoJQLOubq2XM72eNpjF5UdU5o/5NvlNhx95XHcAvcl8OMXr4mlg/fRgUXQ==",
           "dev": true,
           "requires": {
-            "buffer": "5.7.1",
-            "immediate": "3.2.3",
-            "level-concat-iterator": "2.0.1",
-            "level-supports": "1.0.1",
-            "xtend": "4.0.2"
+            "buffer": "^5.5.0",
+            "immediate": "^3.2.3",
+            "level-concat-iterator": "~2.0.0",
+            "level-supports": "~1.0.0",
+            "xtend": "~4.0.0"
           }
         },
         "immediate": {
@@ -12488,13 +12600,13 @@
       "integrity": "sha512-25reMgrT8PhJy0Ba0U7fMZD2oobS1FPWB9vQa0uBpJYIQYYuFXEHoqEkTqA/UzX+s9br3pmUVVY/TOsFt/x0oQ==",
       "dev": true,
       "requires": {
-        "@types/levelup": "4.3.3",
-        "ethereumjs-util": "7.1.0",
-        "level-mem": "5.0.1",
-        "level-ws": "2.0.0",
-        "readable-stream": "3.6.0",
-        "rlp": "2.2.6",
-        "semaphore-async-await": "1.5.1"
+        "@types/levelup": "^4.3.0",
+        "ethereumjs-util": "^7.1.0",
+        "level-mem": "^5.0.1",
+        "level-ws": "^2.0.0",
+        "readable-stream": "^3.6.0",
+        "rlp": "^2.2.4",
+        "semaphore-async-await": "^1.5.1"
       }
     },
     "micromatch": {
@@ -12503,8 +12615,8 @@
       "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
       "dev": true,
       "requires": {
-        "braces": "3.0.2",
-        "picomatch": "2.3.0"
+        "braces": "^3.0.1",
+        "picomatch": "^2.2.3"
       }
     },
     "miller-rabin": {
@@ -12513,8 +12625,8 @@
       "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
       "dev": true,
       "requires": {
-        "bn.js": "4.12.0",
-        "brorand": "1.1.0"
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1"
       }
     },
     "mime-db": {
@@ -12544,7 +12656,7 @@
       "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
       "dev": true,
       "requires": {
-        "dom-walk": "0.1.2"
+        "dom-walk": "^0.1.0"
       }
     },
     "minimalistic-assert": {
@@ -12565,7 +12677,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -12580,7 +12692,7 @@
       "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "dev": true,
       "requires": {
-        "minimist": "1.2.5"
+        "minimist": "^1.2.5"
       }
     },
     "mnemonist": {
@@ -12589,7 +12701,7 @@
       "integrity": "sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==",
       "dev": true,
       "requires": {
-        "obliterator": "1.6.1"
+        "obliterator": "^1.6.1"
       }
     },
     "mocha": {
@@ -12648,14 +12760,14 @@
           "integrity": "sha512-dGmKLDdT3Gdl7fBUe8XK+gAtGmzy5Fn0XkkWQuYxGIgWVPPse2CxFA5mtrlD0TOHaHjEUqkWNyP1XdHoJES/4A==",
           "dev": true,
           "requires": {
-            "anymatch": "3.1.2",
-            "braces": "3.0.2",
-            "fsevents": "2.1.3",
-            "glob-parent": "5.1.2",
-            "is-binary-path": "2.1.0",
-            "is-glob": "4.0.1",
-            "normalize-path": "3.0.0",
-            "readdirp": "3.2.0"
+            "anymatch": "~3.1.1",
+            "braces": "~3.0.2",
+            "fsevents": "~2.1.1",
+            "glob-parent": "~5.1.0",
+            "is-binary-path": "~2.1.0",
+            "is-glob": "~4.0.1",
+            "normalize-path": "~3.0.0",
+            "readdirp": "~3.2.0"
           }
         },
         "cliui": {
@@ -12664,9 +12776,9 @@
           "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
           "dev": true,
           "requires": {
-            "string-width": "3.1.0",
-            "strip-ansi": "5.2.0",
-            "wrap-ansi": "5.1.0"
+            "string-width": "^3.1.0",
+            "strip-ansi": "^5.2.0",
+            "wrap-ansi": "^5.1.0"
           }
         },
         "debug": {
@@ -12675,7 +12787,7 @@
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "dev": true,
           "requires": {
-            "ms": "2.1.1"
+            "ms": "^2.1.1"
           }
         },
         "find-up": {
@@ -12684,7 +12796,7 @@
           "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
           "dev": true,
           "requires": {
-            "locate-path": "3.0.0"
+            "locate-path": "^3.0.0"
           }
         },
         "fsevents": {
@@ -12706,12 +12818,12 @@
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.4",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "is-fullwidth-code-point": {
@@ -12726,8 +12838,8 @@
           "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
           "dev": true,
           "requires": {
-            "p-locate": "3.0.0",
-            "path-exists": "3.0.0"
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
           }
         },
         "ms": {
@@ -12742,10 +12854,10 @@
           "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
           "dev": true,
           "requires": {
-            "define-properties": "1.1.3",
-            "function-bind": "1.1.1",
-            "has-symbols": "1.0.2",
-            "object-keys": "1.1.1"
+            "define-properties": "^1.1.2",
+            "function-bind": "^1.1.1",
+            "has-symbols": "^1.0.0",
+            "object-keys": "^1.0.11"
           }
         },
         "p-limit": {
@@ -12754,7 +12866,7 @@
           "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
           "dev": true,
           "requires": {
-            "p-try": "2.2.0"
+            "p-try": "^2.0.0"
           }
         },
         "p-locate": {
@@ -12763,7 +12875,7 @@
           "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
           "dev": true,
           "requires": {
-            "p-limit": "2.3.0"
+            "p-limit": "^2.0.0"
           }
         },
         "p-try": {
@@ -12784,7 +12896,7 @@
           "integrity": "sha512-crk4Qu3pmXwgxdSgGhgA/eXiJAPQiX4GMOZZMXnqKxHX7TaoL+3gQVo/WeuAiogr07DpnfjIMpXXa+PAIvwPGQ==",
           "dev": true,
           "requires": {
-            "picomatch": "2.3.0"
+            "picomatch": "^2.0.4"
           }
         },
         "require-main-filename": {
@@ -12799,9 +12911,9 @@
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
-            "emoji-regex": "7.0.3",
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "5.2.0"
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
           }
         },
         "strip-ansi": {
@@ -12810,7 +12922,7 @@
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "4.1.0"
+            "ansi-regex": "^4.1.0"
           }
         },
         "supports-color": {
@@ -12819,7 +12931,7 @@
           "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         },
         "which-module": {
@@ -12834,9 +12946,9 @@
           "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "string-width": "3.1.0",
-            "strip-ansi": "5.2.0"
+            "ansi-styles": "^3.2.0",
+            "string-width": "^3.0.0",
+            "strip-ansi": "^5.0.0"
           }
         },
         "y18n": {
@@ -12851,16 +12963,16 @@
           "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
           "dev": true,
           "requires": {
-            "cliui": "5.0.0",
-            "find-up": "3.0.0",
-            "get-caller-file": "2.0.5",
-            "require-directory": "2.1.1",
-            "require-main-filename": "2.0.0",
-            "set-blocking": "2.0.0",
-            "string-width": "3.1.0",
-            "which-module": "2.0.0",
-            "y18n": "4.0.3",
-            "yargs-parser": "13.1.2"
+            "cliui": "^5.0.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^3.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^13.1.2"
           }
         },
         "yargs-parser": {
@@ -12869,8 +12981,8 @@
           "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
           "dev": true,
           "requires": {
-            "camelcase": "5.3.1",
-            "decamelize": "1.2.0"
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
           }
         }
       }
@@ -12905,8 +13017,8 @@
       "integrity": "sha512-5Evy2epuL+6TM0lCQGpFIj6KwiEsGh1SrHUhTbNX+sLbBtjidPZFAnVK9y5yU1+h//RitLbRHTIMyxQPtxMdHw==",
       "dev": true,
       "requires": {
-        "object.getownpropertydescriptors": "2.1.2",
-        "semver": "5.7.1"
+        "object.getownpropertydescriptors": "^2.0.3",
+        "semver": "^5.7.0"
       },
       "dependencies": {
         "semver": {
@@ -12941,10 +13053,10 @@
       "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "2.8.9",
-        "resolve": "1.20.0",
-        "semver": "5.7.1",
-        "validate-npm-package-license": "3.0.4"
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
       },
       "dependencies": {
         "semver": {
@@ -13015,10 +13127,10 @@
       "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
       "dev": true,
       "requires": {
-        "call-bind": "1.0.2",
-        "define-properties": "1.1.3",
-        "has-symbols": "1.0.2",
-        "object-keys": "1.1.1"
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3",
+        "has-symbols": "^1.0.1",
+        "object-keys": "^1.1.1"
       }
     },
     "object.getownpropertydescriptors": {
@@ -13027,9 +13139,9 @@
       "integrity": "sha512-WtxeKSzfBjlzL+F9b7M7hewDzMwy+C8NRssHd1YrNlzHzIDrXcXiNOMrezdAEM4UXixgV+vvnyBeN7Rygl2ttQ==",
       "dev": true,
       "requires": {
-        "call-bind": "1.0.2",
-        "define-properties": "1.1.3",
-        "es-abstract": "1.18.5"
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.18.0-next.2"
       }
     },
     "obliterator": {
@@ -13044,7 +13156,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "open": {
@@ -13053,8 +13165,8 @@
       "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
       "dev": true,
       "requires": {
-        "is-docker": "2.2.1",
-        "is-wsl": "2.2.0"
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
       }
     },
     "os-locale": {
@@ -13063,7 +13175,7 @@
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "dev": true,
       "requires": {
-        "lcid": "1.0.0"
+        "lcid": "^1.0.0"
       }
     },
     "os-tmpdir": {
@@ -13078,7 +13190,7 @@
       "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
       "dev": true,
       "requires": {
-        "p-try": "1.0.0"
+        "p-try": "^1.0.0"
       }
     },
     "p-locate": {
@@ -13087,7 +13199,7 @@
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true,
       "requires": {
-        "p-limit": "1.3.0"
+        "p-limit": "^1.1.0"
       }
     },
     "p-try": {
@@ -13114,7 +13226,7 @@
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
-        "error-ex": "1.3.2"
+        "error-ex": "^1.2.0"
       }
     },
     "patch-package": {
@@ -13123,19 +13235,19 @@
       "integrity": "sha512-S0vh/ZEafZ17hbhgqdnpunKDfzHQibQizx9g8yEf5dcVk3KOflOfdufRXQX8CSEkyOQwuM/bNz1GwKvFj54kaQ==",
       "dev": true,
       "requires": {
-        "@yarnpkg/lockfile": "1.1.0",
-        "chalk": "2.4.2",
-        "cross-spawn": "6.0.5",
-        "find-yarn-workspace-root": "2.0.0",
-        "fs-extra": "7.0.1",
-        "is-ci": "2.0.0",
-        "klaw-sync": "6.0.0",
-        "minimist": "1.2.5",
-        "open": "7.4.2",
-        "rimraf": "2.7.1",
-        "semver": "5.7.1",
-        "slash": "2.0.0",
-        "tmp": "0.0.33"
+        "@yarnpkg/lockfile": "^1.1.0",
+        "chalk": "^2.4.2",
+        "cross-spawn": "^6.0.5",
+        "find-yarn-workspace-root": "^2.0.0",
+        "fs-extra": "^7.0.1",
+        "is-ci": "^2.0.0",
+        "klaw-sync": "^6.0.0",
+        "minimist": "^1.2.0",
+        "open": "^7.4.2",
+        "rimraf": "^2.6.3",
+        "semver": "^5.6.0",
+        "slash": "^2.0.0",
+        "tmp": "^0.0.33"
       },
       "dependencies": {
         "semver": {
@@ -13158,7 +13270,7 @@
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
       "dev": true,
       "requires": {
-        "pinkie-promise": "2.0.1"
+        "pinkie-promise": "^2.0.0"
       }
     },
     "path-is-absolute": {
@@ -13185,9 +13297,9 @@
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.2.8",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "graceful-fs": "^4.1.2",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "pathval": {
@@ -13202,11 +13314,11 @@
       "integrity": "sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==",
       "dev": true,
       "requires": {
-        "create-hash": "1.2.0",
-        "create-hmac": "1.1.7",
-        "ripemd160": "2.0.2",
-        "safe-buffer": "5.2.1",
-        "sha.js": "2.4.11"
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4",
+        "ripemd160": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
       }
     },
     "performance-now": {
@@ -13239,7 +13351,7 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "2.0.4"
+        "pinkie": "^2.0.0"
       }
     },
     "postinstall-postinstall": {
@@ -13278,7 +13390,7 @@
       "integrity": "sha512-W04AqnILOL/sPRXziNicCjSNRruLAuIHEOVBazepu0545DDNGYHz7ar9ZgZ1fMU8/MA4mVxp5rkBWRi6OXIy3Q==",
       "dev": true,
       "requires": {
-        "asap": "2.0.6"
+        "asap": "~2.0.6"
       }
     },
     "prr": {
@@ -13311,9 +13423,9 @@
       "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
       "dev": true,
       "requires": {
-        "decode-uri-component": "0.2.0",
-        "object-assign": "4.1.1",
-        "strict-uri-encode": "1.1.0"
+        "decode-uri-component": "^0.2.0",
+        "object-assign": "^4.1.0",
+        "strict-uri-encode": "^1.0.0"
       }
     },
     "querystring": {
@@ -13328,7 +13440,7 @@
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.2.1"
+        "safe-buffer": "^5.1.0"
       }
     },
     "raw-body": {
@@ -13349,9 +13461,9 @@
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
       "dev": true,
       "requires": {
-        "load-json-file": "1.1.0",
-        "normalize-package-data": "2.5.0",
-        "path-type": "1.1.0"
+        "load-json-file": "^1.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^1.0.0"
       }
     },
     "read-pkg-up": {
@@ -13360,8 +13472,8 @@
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
       "dev": true,
       "requires": {
-        "find-up": "1.1.2",
-        "read-pkg": "1.1.0"
+        "find-up": "^1.0.0",
+        "read-pkg": "^1.0.0"
       }
     },
     "readable-stream": {
@@ -13370,9 +13482,9 @@
       "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.4",
-        "string_decoder": "1.3.0",
-        "util-deprecate": "1.0.2"
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
       }
     },
     "readdirp": {
@@ -13381,7 +13493,7 @@
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "dev": true,
       "requires": {
-        "picomatch": "2.3.0"
+        "picomatch": "^2.2.1"
       }
     },
     "req-cwd": {
@@ -13390,7 +13502,7 @@
       "integrity": "sha1-1AgrTURZgDZkD7c93qAe1T20nrw=",
       "dev": true,
       "requires": {
-        "req-from": "2.0.0"
+        "req-from": "^2.0.0"
       }
     },
     "req-from": {
@@ -13399,7 +13511,7 @@
       "integrity": "sha1-10GI5H+TeW9Kpx327jWuaJ8+DnA=",
       "dev": true,
       "requires": {
-        "resolve-from": "3.0.0"
+        "resolve-from": "^3.0.0"
       }
     },
     "request": {
@@ -13408,26 +13520,26 @@
       "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
       "dev": true,
       "requires": {
-        "aws-sign2": "0.7.0",
-        "aws4": "1.11.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.8",
-        "extend": "3.0.2",
-        "forever-agent": "0.6.1",
-        "form-data": "2.3.3",
-        "har-validator": "5.1.5",
-        "http-signature": "1.2.0",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.32",
-        "oauth-sign": "0.9.0",
-        "performance-now": "2.1.0",
-        "qs": "6.5.2",
-        "safe-buffer": "5.2.1",
-        "tough-cookie": "2.5.0",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.4.0"
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.5.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
       }
     },
     "request-promise-core": {
@@ -13436,7 +13548,7 @@
       "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
       "dev": true,
       "requires": {
-        "lodash": "4.17.21"
+        "lodash": "^4.17.19"
       }
     },
     "request-promise-native": {
@@ -13446,8 +13558,8 @@
       "dev": true,
       "requires": {
         "request-promise-core": "1.1.4",
-        "stealthy-require": "1.1.1",
-        "tough-cookie": "2.5.0"
+        "stealthy-require": "^1.1.1",
+        "tough-cookie": "^2.3.3"
       }
     },
     "require-directory": {
@@ -13474,8 +13586,8 @@
       "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
       "dev": true,
       "requires": {
-        "is-core-module": "2.6.0",
-        "path-parse": "1.0.7"
+        "is-core-module": "^2.2.0",
+        "path-parse": "^1.0.6"
       }
     },
     "resolve-from": {
@@ -13490,7 +13602,7 @@
       "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
       "dev": true,
       "requires": {
-        "glob": "7.1.7"
+        "glob": "^7.1.3"
       }
     },
     "ripemd160": {
@@ -13499,8 +13611,8 @@
       "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
       "dev": true,
       "requires": {
-        "hash-base": "3.1.0",
-        "inherits": "2.0.4"
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
       }
     },
     "rlp": {
@@ -13509,7 +13621,7 @@
       "integrity": "sha512-HAfAmL6SDYNWPUOJNrM500x4Thn4PZsEy5pijPh40U9WfNk0z15hUYzO9xVIMAdIHdFtD8CBDHd75Td1g36Mjg==",
       "dev": true,
       "requires": {
-        "bn.js": "4.12.0"
+        "bn.js": "^4.11.1"
       }
     },
     "rustbn.js": {
@@ -13542,9 +13654,9 @@
       "integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
       "dev": true,
       "requires": {
-        "elliptic": "6.5.4",
-        "node-addon-api": "2.0.2",
-        "node-gyp-build": "4.2.3"
+        "elliptic": "^6.5.2",
+        "node-addon-api": "^2.0.0",
+        "node-gyp-build": "^4.2.0"
       }
     },
     "semaphore-async-await": {
@@ -13583,8 +13695,8 @@
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.4",
-        "safe-buffer": "5.2.1"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "sha1": {
@@ -13593,8 +13705,8 @@
       "integrity": "sha1-rdqnqTFo85PxnrKxUJFhjicA+Eg=",
       "dev": true,
       "requires": {
-        "charenc": "0.0.2",
-        "crypt": "0.0.2"
+        "charenc": ">= 0.0.1",
+        "crypt": ">= 0.0.1"
       }
     },
     "shebang-command": {
@@ -13603,7 +13715,7 @@
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
-        "shebang-regex": "1.0.0"
+        "shebang-regex": "^1.0.0"
       }
     },
     "shebang-regex": {
@@ -13618,9 +13730,9 @@
       "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
       "dev": true,
       "requires": {
-        "call-bind": "1.0.2",
-        "get-intrinsic": "1.1.1",
-        "object-inspect": "1.11.0"
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
       }
     },
     "simple-concat": {
@@ -13635,9 +13747,9 @@
       "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
       "dev": true,
       "requires": {
-        "decompress-response": "3.3.0",
-        "once": "1.4.0",
-        "simple-concat": "1.0.1"
+        "decompress-response": "^3.3.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
       }
     },
     "slash": {
@@ -13652,11 +13764,11 @@
       "integrity": "sha512-o+c6FpkiHd+HPjmjEVpQgH7fqZ14tJpXhho+/bQXlXbliLIS/xjXb42Vxh+qQY1WCSTMQ0+a5vR9vi0MfhU6mA==",
       "dev": true,
       "requires": {
-        "fs-extra": "0.30.0",
-        "memorystream": "0.3.1",
-        "require-from-string": "1.2.1",
-        "semver": "5.7.1",
-        "yargs": "4.8.1"
+        "fs-extra": "^0.30.0",
+        "memorystream": "^0.3.1",
+        "require-from-string": "^1.1.0",
+        "semver": "^5.3.0",
+        "yargs": "^4.7.1"
       },
       "dependencies": {
         "fs-extra": {
@@ -13665,11 +13777,11 @@
           "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.2.8",
-            "jsonfile": "2.4.0",
-            "klaw": "1.3.1",
-            "path-is-absolute": "1.0.1",
-            "rimraf": "2.7.1"
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^2.1.0",
+            "klaw": "^1.0.0",
+            "path-is-absolute": "^1.0.0",
+            "rimraf": "^2.2.8"
           }
         },
         "jsonfile": {
@@ -13678,7 +13790,7 @@
           "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.2.8"
+            "graceful-fs": "^4.1.6"
           }
         },
         "semver": {
@@ -13701,8 +13813,8 @@
       "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
       "dev": true,
       "requires": {
-        "buffer-from": "1.1.2",
-        "source-map": "0.6.1"
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       }
     },
     "spdx-correct": {
@@ -13711,8 +13823,8 @@
       "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
       "dev": true,
       "requires": {
-        "spdx-expression-parse": "3.0.1",
-        "spdx-license-ids": "3.0.10"
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
     "spdx-exceptions": {
@@ -13727,8 +13839,8 @@
       "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
       "dev": true,
       "requires": {
-        "spdx-exceptions": "2.3.0",
-        "spdx-license-ids": "3.0.10"
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
     "spdx-license-ids": {
@@ -13749,15 +13861,15 @@
       "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
       "dev": true,
       "requires": {
-        "asn1": "0.2.4",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.2",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.2",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "safer-buffer": "2.1.2",
-        "tweetnacl": "0.14.5"
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
       }
     },
     "stacktrace-parser": {
@@ -13766,7 +13878,7 @@
       "integrity": "sha512-KJP1OCML99+8fhOHxwwzyWrlUuVX5GQ0ZpJTd1DFXhdkrvg1szxfHhawXUZ3g9TkXORQd4/WG68jMlQZ2p8wlg==",
       "dev": true,
       "requires": {
-        "type-fest": "0.7.1"
+        "type-fest": "^0.7.1"
       },
       "dependencies": {
         "type-fest": {
@@ -13801,9 +13913,9 @@
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "dev": true,
       "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
-        "strip-ansi": "3.0.1"
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
       }
     },
     "string.prototype.trimend": {
@@ -13812,8 +13924,8 @@
       "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
       "dev": true,
       "requires": {
-        "call-bind": "1.0.2",
-        "define-properties": "1.1.3"
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
       }
     },
     "string.prototype.trimstart": {
@@ -13822,8 +13934,8 @@
       "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
       "dev": true,
       "requires": {
-        "call-bind": "1.0.2",
-        "define-properties": "1.1.3"
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
       }
     },
     "string_decoder": {
@@ -13832,7 +13944,7 @@
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.2.1"
+        "safe-buffer": "~5.2.0"
       }
     },
     "strip-ansi": {
@@ -13841,7 +13953,7 @@
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "strip-bom": {
@@ -13850,7 +13962,7 @@
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
       "dev": true,
       "requires": {
-        "is-utf8": "0.2.1"
+        "is-utf8": "^0.2.0"
       }
     },
     "strip-hex-prefix": {
@@ -13874,7 +13986,7 @@
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "dev": true,
       "requires": {
-        "has-flag": "3.0.0"
+        "has-flag": "^3.0.0"
       }
     },
     "sync-request": {
@@ -13883,9 +13995,9 @@
       "integrity": "sha512-8fjNkrNlNCrVc/av+Jn+xxqfCjYaBoHqCsDz6mt030UMxJGr+GSfCV1dQt2gRtlL63+VPidwDVLr7V2OcTSdRw==",
       "dev": true,
       "requires": {
-        "http-response-object": "3.0.2",
-        "sync-rpc": "1.3.6",
-        "then-request": "6.0.2"
+        "http-response-object": "^3.0.1",
+        "sync-rpc": "^1.2.1",
+        "then-request": "^6.0.0"
       }
     },
     "sync-rpc": {
@@ -13894,7 +14006,7 @@
       "integrity": "sha512-J8jTXuZzRlvU7HemDgHi3pGnh/rkoqR/OZSjhTyyZrEkkYQbk7Z33AXp37mkPfPpfdOuj7Ex3H/TJM1z48uPQw==",
       "dev": true,
       "requires": {
-        "get-port": "3.2.0"
+        "get-port": "^3.1.0"
       }
     },
     "test-value": {
@@ -13903,8 +14015,8 @@
       "integrity": "sha1-Edpv9nDzRxpztiXKTz/c97t0gpE=",
       "dev": true,
       "requires": {
-        "array-back": "1.0.4",
-        "typical": "2.6.1"
+        "array-back": "^1.0.3",
+        "typical": "^2.6.0"
       },
       "dependencies": {
         "array-back": {
@@ -13913,7 +14025,7 @@
           "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
           "dev": true,
           "requires": {
-            "typical": "2.6.1"
+            "typical": "^2.6.0"
           }
         }
       }
@@ -13930,17 +14042,17 @@
       "integrity": "sha512-3ZBiG7JvP3wbDzA9iNY5zJQcHL4jn/0BWtXIkagfz7QgOL/LqjCEOBQuJNZfu0XYnv5JhKh+cDxCPM4ILrqruA==",
       "dev": true,
       "requires": {
-        "@types/concat-stream": "1.6.1",
+        "@types/concat-stream": "^1.6.0",
         "@types/form-data": "0.0.33",
-        "@types/node": "8.10.66",
-        "@types/qs": "6.9.7",
-        "caseless": "0.12.0",
-        "concat-stream": "1.6.2",
-        "form-data": "2.3.3",
-        "http-basic": "8.1.3",
-        "http-response-object": "3.0.2",
-        "promise": "8.1.0",
-        "qs": "6.5.2"
+        "@types/node": "^8.0.0",
+        "@types/qs": "^6.2.31",
+        "caseless": "~0.12.0",
+        "concat-stream": "^1.6.0",
+        "form-data": "^2.2.0",
+        "http-basic": "^8.1.1",
+        "http-response-object": "^3.0.1",
+        "promise": "^8.0.0",
+        "qs": "^6.4.0"
       },
       "dependencies": {
         "@types/node": {
@@ -13963,7 +14075,7 @@
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "dev": true,
       "requires": {
-        "os-tmpdir": "1.0.2"
+        "os-tmpdir": "~1.0.2"
       }
     },
     "to-regex-range": {
@@ -13972,7 +14084,7 @@
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dev": true,
       "requires": {
-        "is-number": "7.0.0"
+        "is-number": "^7.0.0"
       }
     },
     "toidentifier": {
@@ -13987,8 +14099,8 @@
       "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
       "dev": true,
       "requires": {
-        "psl": "1.8.0",
-        "punycode": "2.1.1"
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
       },
       "dependencies": {
         "punycode": {
@@ -14017,15 +14129,15 @@
       "integrity": "sha512-N+ahhZxTLYu1HNTQetwWcx3so8hcYbkKBHTr4b4/YgObFTIKkOSSsaa+nal12w8mfrJAyzJfETXawbNjSfP2gQ==",
       "dev": true,
       "requires": {
-        "@types/mkdirp": "0.5.2",
-        "@types/prettier": "2.3.2",
-        "@types/resolve": "0.0.8",
-        "chalk": "2.4.2",
-        "glob": "7.1.7",
-        "mkdirp": "0.5.5",
-        "prettier": "2.3.2",
-        "resolve": "1.20.0",
-        "ts-essentials": "1.0.4"
+        "@types/mkdirp": "^0.5.2",
+        "@types/prettier": "^2.1.1",
+        "@types/resolve": "^0.0.8",
+        "chalk": "^2.4.1",
+        "glob": "^7.1.2",
+        "mkdirp": "^0.5.1",
+        "prettier": "^2.1.2",
+        "resolve": "^1.8.1",
+        "ts-essentials": "^1.0.0"
       }
     },
     "ts-node": {
@@ -14035,16 +14147,16 @@
       "dev": true,
       "requires": {
         "@cspotcode/source-map-support": "0.6.1",
-        "@tsconfig/node10": "1.0.8",
-        "@tsconfig/node12": "1.0.9",
-        "@tsconfig/node14": "1.0.1",
-        "@tsconfig/node16": "1.0.2",
-        "acorn": "8.4.1",
-        "acorn-walk": "8.1.1",
-        "arg": "4.1.3",
-        "create-require": "1.1.1",
-        "diff": "4.0.2",
-        "make-error": "1.3.6",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
         "yn": "3.1.1"
       },
       "dependencies": {
@@ -14074,7 +14186,7 @@
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.2.1"
+        "safe-buffer": "^5.0.1"
       }
     },
     "tweetnacl": {
@@ -14107,13 +14219,13 @@
       "integrity": "sha512-ft4KVmiN3zH4JUFu2WJBrwfHeDf772Tt2d8bssDTo/YcckKW2D+OwFrHXRC6hJvO3mHjFQTihoMV6fJOi0Hngg==",
       "dev": true,
       "requires": {
-        "command-line-args": "4.0.7",
-        "debug": "4.3.2",
-        "fs-extra": "7.0.1",
-        "js-sha3": "0.8.0",
-        "lodash": "4.17.21",
-        "ts-essentials": "6.0.7",
-        "ts-generator": "0.1.1"
+        "command-line-args": "^4.0.7",
+        "debug": "^4.1.1",
+        "fs-extra": "^7.0.0",
+        "js-sha3": "^0.8.0",
+        "lodash": "^4.17.15",
+        "ts-essentials": "^6.0.3",
+        "ts-generator": "^0.1.1"
       },
       "dependencies": {
         "js-sha3": {
@@ -14154,10 +14266,10 @@
       "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
       "dev": true,
       "requires": {
-        "function-bind": "1.1.1",
-        "has-bigints": "1.0.1",
-        "has-symbols": "1.0.2",
-        "which-boxed-primitive": "1.0.2"
+        "function-bind": "^1.1.1",
+        "has-bigints": "^1.0.1",
+        "has-symbols": "^1.0.2",
+        "which-boxed-primitive": "^1.0.2"
       }
     },
     "universalify": {
@@ -14178,7 +14290,7 @@
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
       "requires": {
-        "punycode": "2.1.0"
+        "punycode": "^2.1.0"
       }
     },
     "url": {
@@ -14223,11 +14335,11 @@
       "integrity": "sha512-/s3UsZUrIfa6xDhr7zZhnE9SLQ5RIXyYfiVnMMyMDzOc8WhWN4Nbh36H842OyurKbCDAesZOJaVyvmSl6fhGQw==",
       "dev": true,
       "requires": {
-        "call-bind": "1.0.2",
-        "define-properties": "1.1.3",
-        "for-each": "0.3.3",
-        "has-symbols": "1.0.2",
-        "object.getownpropertydescriptors": "2.1.2"
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3",
+        "for-each": "^0.3.3",
+        "has-symbols": "^1.0.1",
+        "object.getownpropertydescriptors": "^2.1.1"
       }
     },
     "uuid": {
@@ -14242,8 +14354,8 @@
       "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
       "dev": true,
       "requires": {
-        "spdx-correct": "3.1.1",
-        "spdx-expression-parse": "3.0.1"
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
       }
     },
     "verror": {
@@ -14252,9 +14364,9 @@
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0",
+        "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
+        "extsprintf": "^1.2.0"
       }
     },
     "web3-utils": {
@@ -14263,12 +14375,12 @@
       "integrity": "sha512-quTtTeQJHYSxAwIBOCGEcQtqdVcFWX6mCFNoqnp+mRbq+Hxbs8CGgO/6oqfBx4OvxIOfCpgJWYVHswRXnbEu9Q==",
       "dev": true,
       "requires": {
-        "bn.js": "4.12.0",
+        "bn.js": "^4.11.9",
         "eth-lib": "0.2.8",
-        "ethereum-bloom-filters": "1.0.10",
+        "ethereum-bloom-filters": "^1.0.6",
         "ethjs-unit": "0.1.6",
         "number-to-bn": "1.7.0",
-        "randombytes": "2.1.0",
+        "randombytes": "^2.1.0",
         "utf8": "3.0.0"
       }
     },
@@ -14278,7 +14390,7 @@
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dev": true,
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "which-boxed-primitive": {
@@ -14287,11 +14399,11 @@
       "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
       "dev": true,
       "requires": {
-        "is-bigint": "1.0.4",
-        "is-boolean-object": "1.1.2",
-        "is-number-object": "1.0.6",
-        "is-string": "1.0.7",
-        "is-symbol": "1.0.4"
+        "is-bigint": "^1.0.1",
+        "is-boolean-object": "^1.1.0",
+        "is-number-object": "^1.0.4",
+        "is-string": "^1.0.5",
+        "is-symbol": "^1.0.3"
       }
     },
     "which-module": {
@@ -14306,7 +14418,7 @@
       "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
       "dev": true,
       "requires": {
-        "string-width": "1.0.2"
+        "string-width": "^1.0.2 || 2"
       }
     },
     "window-size": {
@@ -14321,8 +14433,8 @@
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1"
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1"
       }
     },
     "wrappy": {
@@ -14343,10 +14455,10 @@
       "integrity": "sha512-/eCGLb5rxjx5e3mF1A7s+pLlR6CGyqWN91fv1JgER5mVWg1MZmlhBvy9kjcsOdRk8RrIujotWyJamfyrp+WIcA==",
       "dev": true,
       "requires": {
-        "global": "4.4.0",
-        "is-function": "1.0.2",
-        "parse-headers": "2.0.4",
-        "xtend": "4.0.2"
+        "global": "~4.4.0",
+        "is-function": "^1.0.1",
+        "parse-headers": "^2.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "xhr-request": {
@@ -14355,13 +14467,13 @@
       "integrity": "sha512-Y7qzEaR3FDtL3fP30k9wO/e+FBnBByZeybKOhASsGP30NIkRAAkKD/sCnLvgEfAIEC1rcmK7YG8f4oEnIrrWzA==",
       "dev": true,
       "requires": {
-        "buffer-to-arraybuffer": "0.0.5",
-        "object-assign": "4.1.1",
-        "query-string": "5.1.1",
-        "simple-get": "2.8.1",
-        "timed-out": "4.0.1",
-        "url-set-query": "1.0.0",
-        "xhr": "2.6.0"
+        "buffer-to-arraybuffer": "^0.0.5",
+        "object-assign": "^4.1.1",
+        "query-string": "^5.0.1",
+        "simple-get": "^2.7.0",
+        "timed-out": "^4.0.1",
+        "url-set-query": "^1.0.0",
+        "xhr": "^2.0.4"
       }
     },
     "xhr-request-promise": {
@@ -14370,7 +14482,7 @@
       "integrity": "sha512-YUBytBsuwgitWtdRzXDDkWAXzhdGB8bYm0sSzMPZT7Z2MBjMSTHFsyCT1yCRATY+XC69DUrQraRAEgcoCRaIPg==",
       "dev": true,
       "requires": {
-        "xhr-request": "1.1.0"
+        "xhr-request": "^1.1.0"
       }
     },
     "xmlhttprequest": {
@@ -14403,20 +14515,20 @@
       "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
       "dev": true,
       "requires": {
-        "cliui": "3.2.0",
-        "decamelize": "1.2.0",
-        "get-caller-file": "1.0.3",
-        "lodash.assign": "4.2.0",
-        "os-locale": "1.4.0",
-        "read-pkg-up": "1.0.1",
-        "require-directory": "2.1.1",
-        "require-main-filename": "1.0.1",
-        "set-blocking": "2.0.0",
-        "string-width": "1.0.2",
-        "which-module": "1.0.0",
-        "window-size": "0.2.0",
-        "y18n": "3.2.2",
-        "yargs-parser": "2.4.1"
+        "cliui": "^3.2.0",
+        "decamelize": "^1.1.1",
+        "get-caller-file": "^1.0.1",
+        "lodash.assign": "^4.0.3",
+        "os-locale": "^1.4.0",
+        "read-pkg-up": "^1.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^1.0.1",
+        "set-blocking": "^2.0.0",
+        "string-width": "^1.0.1",
+        "which-module": "^1.0.0",
+        "window-size": "^0.2.0",
+        "y18n": "^3.2.1",
+        "yargs-parser": "^2.4.1"
       }
     },
     "yargs-parser": {
@@ -14425,8 +14537,8 @@
       "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
       "dev": true,
       "requires": {
-        "camelcase": "3.0.0",
-        "lodash.assign": "4.2.0"
+        "camelcase": "^3.0.0",
+        "lodash.assign": "^4.0.6"
       }
     },
     "yargs-unparser": {
@@ -14435,9 +14547,9 @@
       "integrity": "sha512-W9tKgmSn0DpSatfri0nx52Joq5hVXgeLiqR/5G0sZNDoLZFOr/xjBUDcShCOGNsBnEMNo1KAMBkTej1Hm62HTw==",
       "dev": true,
       "requires": {
-        "flat": "4.1.1",
-        "lodash": "4.17.21",
-        "yargs": "13.3.2"
+        "flat": "^4.1.0",
+        "lodash": "^4.17.15",
+        "yargs": "^13.3.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -14458,9 +14570,9 @@
           "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
           "dev": true,
           "requires": {
-            "string-width": "3.1.0",
-            "strip-ansi": "5.2.0",
-            "wrap-ansi": "5.1.0"
+            "string-width": "^3.1.0",
+            "strip-ansi": "^5.2.0",
+            "wrap-ansi": "^5.1.0"
           }
         },
         "find-up": {
@@ -14469,7 +14581,7 @@
           "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
           "dev": true,
           "requires": {
-            "locate-path": "3.0.0"
+            "locate-path": "^3.0.0"
           }
         },
         "get-caller-file": {
@@ -14490,8 +14602,8 @@
           "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
           "dev": true,
           "requires": {
-            "p-locate": "3.0.0",
-            "path-exists": "3.0.0"
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
           }
         },
         "p-limit": {
@@ -14500,7 +14612,7 @@
           "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
           "dev": true,
           "requires": {
-            "p-try": "2.2.0"
+            "p-try": "^2.0.0"
           }
         },
         "p-locate": {
@@ -14509,7 +14621,7 @@
           "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
           "dev": true,
           "requires": {
-            "p-limit": "2.3.0"
+            "p-limit": "^2.0.0"
           }
         },
         "p-try": {
@@ -14536,9 +14648,9 @@
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
-            "emoji-regex": "7.0.3",
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "5.2.0"
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
           }
         },
         "strip-ansi": {
@@ -14547,7 +14659,7 @@
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "4.1.0"
+            "ansi-regex": "^4.1.0"
           }
         },
         "which-module": {
@@ -14562,9 +14674,9 @@
           "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "string-width": "3.1.0",
-            "strip-ansi": "5.2.0"
+            "ansi-styles": "^3.2.0",
+            "string-width": "^3.0.0",
+            "strip-ansi": "^5.0.0"
           }
         },
         "y18n": {
@@ -14579,16 +14691,16 @@
           "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
           "dev": true,
           "requires": {
-            "cliui": "5.0.0",
-            "find-up": "3.0.0",
-            "get-caller-file": "2.0.5",
-            "require-directory": "2.1.1",
-            "require-main-filename": "2.0.0",
-            "set-blocking": "2.0.0",
-            "string-width": "3.1.0",
-            "which-module": "2.0.0",
-            "y18n": "4.0.3",
-            "yargs-parser": "13.1.2"
+            "cliui": "^5.0.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^3.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^13.1.2"
           }
         },
         "yargs-parser": {
@@ -14597,8 +14709,8 @@
           "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
           "dev": true,
           "requires": {
-            "camelcase": "5.3.1",
-            "decamelize": "1.2.0"
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
           }
         }
       }


### PR DESCRIPTION
list of changes:
-Add SPDX-License-Identifier
-New syntax for abstract functions
-Remove SafeMath
-Change functional math to operators
-Extract votesByMember from Proposal to top level mapping voteHistory as
compiler will not ignore nested mapping in struct
-Change setters and getters to use new voteHistory mapping
-Exchange "now" for block.timestamp
-Update function param name to "shouldWithdrawMax" to avoid conflict with
contract function name "max"
-Change shorthand uint(-1) to const MAX_INT as shorthand no longer works
-Cast msg.sender as payable because transfer needs a payable address
-New syntax for address.call(value)() to address.call{value:value}()

-Updated the 0.8 version in hardhat.config to 0.8.4 because 0.8.0 was throwing the following error on compile due to its optimization:
CompilerError: Stack too deep when compiling inline assembly: Variable value0 is 1 slot(s) too deep inside the stack.

Notes:
This should not be functionally different from the previous code in any way.
Some changes were made to remove compiler warnings and not for addressing errors.

HIGHLIGHT FOR SECURITY CHECKS:
There are no tests in this repo to verify that v0.8.0+ guards against overflow without SafeMath.  I am taking it on faith that the solidity compiler does as advertised.
I do not fully understand the edge case uint(-1) is trying to catch in Wrapper.  I just read that the value of uint(-1) used to resolve to the same as the max for uint before the compiler decided it did not like this shorthand.